### PR TITLE
Pipeline tests execution time revised

### DIFF
--- a/dff/core/pipeline/messenger_interface.py
+++ b/dff/core/pipeline/messenger_interface.py
@@ -65,7 +65,7 @@ class PollingMessengerInterface(MessengerInterface):
         self,
         pipeline_runner: PipelineRunnerFunction,
         loop: PollingProviderLoopFunction = lambda: True,
-        timeout: int = 0,
+        timeout: float = 0,
     ):
         """
         Method, running a request - response cycle in a loop.

--- a/dff/core/pipeline/pipeline/component.py
+++ b/dff/core/pipeline/pipeline/component.py
@@ -31,7 +31,7 @@ class PipelineComponent(abc.ABC):
     :type before_handler: :py:class:`~pipeline.BeforeHandler`
     :param after_handler: after handler, associated with this component
     :type before_handler: :py:class:`~pipeline.AfterHandler`
-    :param int timeout: (for asynchronous only!) maximum component execution time (in seconds),
+    :param float timeout: (for asynchronous only!) maximum component execution time (in seconds),
     if it exceeds this time, it is interrupted
     :param bool requested_async_flag: requested asynchronous property;
     if not defined, calculated_async_flag is used instead
@@ -53,7 +53,7 @@ class PipelineComponent(abc.ABC):
         self,
         before_handler: Optional[ExtraHandlerBuilder] = None,
         after_handler: Optional[ExtraHandlerBuilder] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
         requested_async_flag: Optional[bool] = None,
         calculated_async_flag: bool = False,
         start_condition: Optional[StartConditionCheckerFunction] = None,

--- a/dff/core/pipeline/pipeline/pipeline.py
+++ b/dff/core/pipeline/pipeline/pipeline.py
@@ -46,7 +46,7 @@ class Pipeline:
         context_storage: Optional[Union[DBAbstractConnector, Dict]] = None,
         before_handler: Optional[ExtraHandlerBuilder] = None,
         after_handler: Optional[ExtraHandlerBuilder] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
         optimization_warnings: bool = False,
     ):
         self.messenger_interface = CLIMessengerInterface() if messenger_interface is None else messenger_interface

--- a/dff/core/pipeline/service/extra.py
+++ b/dff/core/pipeline/service/extra.py
@@ -31,7 +31,7 @@ class _ComponentExtraHandler:
         self,
         functions: ExtraHandlerBuilder,
         stage: ExtraHandlerType = ExtraHandlerType.UNDEFINED,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
         asynchronous: Optional[bool] = None,
     ):
         overridden_parameters = collect_defined_constructor_parameters_to_dict(

--- a/dff/core/pipeline/service/group.py
+++ b/dff/core/pipeline/service/group.py
@@ -45,7 +45,7 @@ class ServiceGroup(PipelineComponent):
         components: ServiceGroupBuilder,
         before_handler: Optional[ExtraHandlerBuilder] = None,
         after_handler: Optional[ExtraHandlerBuilder] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
         asynchronous: Optional[bool] = None,
         start_condition: Optional[StartConditionCheckerFunction] = None,
         name: Optional[str] = None,

--- a/dff/core/pipeline/service/service.py
+++ b/dff/core/pipeline/service/service.py
@@ -40,7 +40,7 @@ class Service(PipelineComponent):
         handler: ServiceBuilder,
         before_handler: Optional[ExtraHandlerBuilder] = None,
         after_handler: Optional[ExtraHandlerBuilder] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
         asynchronous: Optional[bool] = None,
         start_condition: Optional[StartConditionCheckerFunction] = None,
         name: Optional[str] = None,

--- a/dff/core/pipeline/types.py
+++ b/dff/core/pipeline/types.py
@@ -120,7 +120,7 @@ ServiceRuntimeInfo = TypedDict(
     {
         "name": str,
         "path": str,
-        "timeout": Optional[int],
+        "timeout": Optional[float],
         "asynchronous": bool,
         "execution_state": Dict[str, ComponentExecutionState],
     },
@@ -173,7 +173,7 @@ ExtraHandlerBuilder = Union[
     TypedDict(
         "WrapperDict",
         {
-            "timeout": NotRequired[Optional[int]],
+            "timeout": NotRequired[Optional[float]],
             "asynchronous": NotRequired[bool],
             "functions": List[ExtraHandlerFunction],
         },
@@ -200,7 +200,7 @@ ServiceBuilder = Union[
             "handler": "ServiceBuilder",
             "before_handler": NotRequired[Optional[ExtraHandlerBuilder]],
             "after_handler": NotRequired[Optional[ExtraHandlerBuilder]],
-            "timeout": NotRequired[Optional[int]],
+            "timeout": NotRequired[Optional[float]],
             "asynchronous": NotRequired[bool],
             "start_condition": NotRequired[StartConditionCheckerFunction],
             "name": Optional[str],

--- a/examples/pipeline/5_asynchronous_groups_and_services_basic.py
+++ b/examples/pipeline/5_asynchronous_groups_and_services_basic.py
@@ -24,8 +24,8 @@ In asynchronous service groups all services are executed simultaneously.
 Service can be asynchronous if its handler is an async function.
 Service group can be asynchronous if all services and service groups inside it are asynchronous.
 
-Here there is an asynchronous service group, that contains 10 services, each of them should sleep for 1 second.
-However, as the group is asynchronous, it is being executed for 1 second in total.
+Here there is an asynchronous service group, that contains 10 services, each of them should sleep for 0.01 of a second.
+However, as the group is asynchronous, it is being executed for 0.01 of a second in total.
 Service group `pipeline` can't be asynchronous because actor is synchronous.
 """
 
@@ -38,7 +38,7 @@ actor = Actor(
 
 
 async def time_consuming_service(_):
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.01)
 
 
 pipeline_dict = {

--- a/examples/pipeline/5_asynchronous_groups_and_services_full.py
+++ b/examples/pipeline/5_asynchronous_groups_and_services_full.py
@@ -44,8 +44,8 @@ Synchronous services should be expelled from (mostly) asynchronous groups.
 
 Here service group `balanced_group` can be asynchronous, however it is requested to be synchronous,
     so its services are executed consequently.
-Service group `service_group_0` is asynchronous, it doesn't run out of timeout of 2 seconds,
-    however contains 6 time consuming services, each of them sleeps for a second.
+Service group `service_group_0` is asynchronous, it doesn't run out of timeout of 0.02 seconds,
+    however contains 6 time consuming services, each of them sleeps for 0.01 of a second.
 Service group `service_group_1` is also asynchronous, it logs HTTPS requests (from 1 to 15),
     running simultaneously, in random order.
 Service group `pipeline` can't be asynchronous because `balanced_group` and actor are synchronous.
@@ -64,7 +64,7 @@ async def simple_asynchronous_service(_, __, info: ServiceRuntimeInfo):
 
 
 async def time_consuming_service(_):
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.01)
 
 
 def meta_web_querying_service(photo_number: int):  # This function returns services, a service factory
@@ -93,7 +93,7 @@ pipeline_dict = {
             asynchronous=False,
             components=[
                 simple_asynchronous_service,
-                ServiceGroup(timeout=2, components=[time_consuming_service for _ in range(0, 6)]),
+                ServiceGroup(timeout=0.02, components=[time_consuming_service for _ in range(0, 6)]),
                 simple_asynchronous_service,
             ],
         ),

--- a/examples/pipeline/7_extra_handlers_basic.py
+++ b/examples/pipeline/7_extra_handlers_basic.py
@@ -26,7 +26,7 @@ Extra handlers main purpose should be service and service groups statistics coll
 Extra handlers can be attached to pipeline component using `before_handler` and `after_handler` constructor parameter.
 
 Here 5 `heavy_service`s are run in single asynchronous service group.
-Each of them sleeps for random amount of seconds (between 0 and 5).
+Each of them sleeps for random amount of seconds (between 0 and 0.05).
 To each of them (as well as to group) time measurement extra handler is attached,
     that writes execution time to `ctx.misc`.
 In the end `ctx.misc` is logged to info channel.
@@ -49,7 +49,7 @@ actor = Actor(
 
 
 async def heavy_service(_):
-    await asyncio.sleep(random.randint(0, 5))
+    await asyncio.sleep(random.randint(0, 5) / 100)
 
 
 def logging_service(ctx: Context):

--- a/examples/pipeline/8_extra_handlers_and_extensions.py
+++ b/examples/pipeline/8_extra_handlers_and_extensions.py
@@ -49,7 +49,7 @@ Pipeline `add_global_extra_handler` function is used to register global extra ha
 Here basic functionality of `df-node-stats` library is emulated.
 Information about pipeline component execution time and
     result is collected and printed to info log after pipeline execution.
-Pipeline consists of actor and 25 `long_service`s that run random amount of time between 0 and 5 seconds.
+Pipeline consists of actor and 25 `long_service`s that run random amount of time between 0 and 0.05 seconds.
 """
 
 
@@ -92,7 +92,7 @@ def after_all(_, __, info: ExtraHandlerRuntimeInfo):
 
 
 async def long_service(_, __, info: ServiceRuntimeInfo):
-    timeout = random.randint(0, 5)
+    timeout = random.randint(0, 5) / 100
     logger.info(f"Service {info['name']} is going to sleep for {timeout} seconds.")
     await asyncio.sleep(timeout)
 


### PR DESCRIPTION
Pipeline tests time limitation reduced 100 times.
However, there are still tests that require web queries that take up to 15 seconds to run.