### PR TITLE
Remove output redirection to pytest-coverage.txt for non_linux_test job

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -55,5 +55,5 @@ jobs:
         shell: bash
 
       - name: build coverage file
-        run: pytest --tb=long -vv --cache-clear --cov=dff tests/ > pytest-coverage.txt
+        run: pytest --tb=long -vv --cache-clear --cov=dff tests/
         shell: bash


### PR DESCRIPTION
This prevented access to macOS and Windows logs.