### PR TITLE
Revert makefile lint and format targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -35,18 +35,18 @@ venv_test:
 	pip install -e .[test_full]
 
 format: venv
-	black --line-length=120 . --exclude venv,build
+	black --line-length=120 dff
 .PHONY: format
 
 lint: venv
-	flake8 --max-line-length 120 . --exclude venv,build
-	@set -e && black --line-length=120 --check . --exclude venv,build|| ( \
+	flake8 --max-line-length 120 dff
+	@set -e && black --line-length=120 --check dff|| ( \
 		echo "================================"; \
 		echo "Bad formatting? Run: make format"; \
 		echo "================================"; \
 		false)
 	# TODO: Add mypy testing
-	# @mypy . --exclude venv,build
+	# @mypy dff
 .PHONY: lint
 
 docker_up:


### PR DESCRIPTION
# Description

This change was done in e4b58870eea090a3a176485e5d7d900f99734e1a without proper discussion. The change affects parser tests and implementing it would require rewriting those tests.

Also, it significantly affects performance because it doesn't exclude all possible directories.

A better way to cover tests and examples during lint job would be to explicitly list them:
`flake8 --max-line-length 120 dff tests examples`