### PR TITLE
Exclude any venvs from lint and format

### DIFF
--- a/makefile
+++ b/makefile
@@ -35,18 +35,18 @@ venv_test:
 	pip install -e .[test_full]
 
 format: venv
-	black --line-length=120 . --exclude venv,build
+	black --line-length=120 . --exclude venv*,build
 .PHONY: format
 
 lint: venv
-	flake8 --max-line-length 120 . --exclude venv,build
-	@set -e && black --line-length=120 --check . --exclude venv,build|| ( \
+	flake8 --max-line-length 120 . --exclude venv*,build
+	@set -e && black --line-length=120 --check . --exclude venv*,build|| ( \
 		echo "================================"; \
 		echo "Bad formatting? Run: make format"; \
 		echo "================================"; \
 		false)
 	# TODO: Add mypy testing
-	# @mypy . --exclude venv,build
+	# @mypy . --exclude venv*,build
 .PHONY: lint
 
 docker_up:


### PR DESCRIPTION
# Description

Exclude all files starting with `venv` from lint and format.