### PR TITLE
Fix make help typo

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ help:
 	@echo "make test: Run basic tests (not testing most integrations)"
 	@echo "make test_all: Run ALL tests (slow, closest to CI)"
 	@echo "make format: Run code formatters (destructive)"
-	@echo "make build_doc: Build Sphinx docs; activate your virtual environment before execution"
+	@echo "make doc: Build Sphinx docs; activate your virtual environment before execution"
 	@echo "make pre_commit: Register a git hook to lint the code on each commit"
 	@echo "make version_major: increment version major in metadata files 8.8.1 -> 9.0.0"
 	@echo "make version_minor: increment version minor in metadata files 9.1.1 -> 9.2.0"


### PR DESCRIPTION
# Description

Update help message to display `make doc` instead of `make build_doc`.

# Checklist

- [x] I have covered the code with tests
- [x] I have added comments to my code to help others understand it
- [x] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes