### PR TITLE
Report coverage only on python3.10

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -28,7 +28,7 @@ jobs:
       - name: set up python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: install dependencies
         run: make venv_test

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -12,11 +12,9 @@ on:
 
 
 jobs:
-  linux_test:
+  test_coverage:
     strategy:
       fail-fast: false
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     runs-on: ubuntu-latest
 
@@ -27,10 +25,10 @@ jobs:
         run: |
           docker-compose up -d
 
-      - name: set up python ${{ matrix.python-version }}
+      - name: set up python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.10
 
       - name: install dependencies
         run: make venv_test
@@ -38,30 +36,4 @@ jobs:
 
       - name: build coverage file
         run: make test
-        shell: bash
-
-  non_linux_test:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [macOS-latest, windows-latest]
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[test_full]
-        shell: bash
-
-      - name: build coverage file
-        run: pytest --tb=long -vv --cache-clear --cov=dff tests/
         shell: bash

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -39,10 +39,12 @@ jobs:
           pip install -e .[test_full]
         shell: bash
 
-      - name: build coverage file
+      - name: add env variables
+        if: matrix.os == 'ubuntu-latest'
         run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-              source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /')
-          fi
+          source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /')
+
+      - name: run pytest
+        run: |
           pytest --tb=long -vv --cache-clear --cov=dff tests/
         shell: bash

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -42,8 +42,7 @@ jobs:
       - name: build coverage file
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-              make test
-          else
-              pytest --tb=long -vv --cache-clear --cov=dff tests/
+              source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /')
           fi
+          pytest --tb=long -vv --cache-clear --cov=dff tests/
         shell: bash

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -39,7 +39,7 @@ jobs:
           pip install -e .[test_full]
         shell: bash
 
-      - name: build coverage file
+      - name: run pytest
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
               source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /')

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -40,5 +40,10 @@ jobs:
         shell: bash
 
       - name: build coverage file
-        run: pytest --tb=long -vv --cache-clear --cov=dff tests/
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+              make test
+          else
+              pytest --tb=long -vv --cache-clear --cov=dff tests/
+          fi
         shell: bash

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -1,0 +1,44 @@
+name: test_full
+
+on:
+  push:
+    branches:
+    - dev
+    - test/**
+  pull_request:
+    branches:
+    - dev
+  workflow_dispatch:
+
+
+jobs:
+  test_full:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: [macOS-latest, windows-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build images
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          docker-compose up -d
+
+      - name: set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test_full]
+        shell: bash
+
+      - name: build coverage file
+        run: pytest --tb=long -vv --cache-clear --cov=dff tests/
+        shell: bash

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -39,12 +39,10 @@ jobs:
           pip install -e .[test_full]
         shell: bash
 
-      - name: add env variables
-        if: matrix.os == 'ubuntu-latest'
+      - name: build coverage file
         run: |
-          source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /')
-
-      - name: run pytest
-        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+              source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /')
+          fi
           pytest --tb=long -vv --cache-clear --cov=dff tests/
         shell: bash


### PR DESCRIPTION
# Description

This is done because test coverage differs depending on python version (https://coverage.readthedocs.io/en/6.6.0b1/faq.html#q-my-decorator-lines-are-marked-as-covered-but-the-def-line-is-not-why).

Also splitting into two different workflows would allow in the future to have different triggers for a full set of tests and for ubuntu-python3.10 tests.