### PR TITLE
Run tests in an isolated environment

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -30,10 +30,24 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: install dependencies
-        run: make venv_test
-        shell: bash
+      - name: install package
+        run: |
+          python -m pip install build
+          python -m build
+          find . -name "*.whl" -exec python -m pip install {}[test_full] ';'
 
-      - name: build coverage file
-        run: make test
+      - name: prepare testing environment
+        run: |
+          mkdir /tmp/testing_files
+          cp -r tests /tmp/testing_files
+          cp -r examples /tmp/testing_files
+          cp .env_file /tmp/testing_files
+          cp makefile /tmp/testing_files
+          rm -r ./*
+          cp -r /tmp/testing_files/* .
+          touch venv  # disable venv target
+
+      - name: run tests
+        run: |
+          make test
         shell: bash

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -40,10 +40,11 @@ jobs:
         run: |
           export backup_files=( tests examples .env_file makefile )
           mkdir /tmp/backup
-          for i in $backup_files; do mv $i  /tmp/backup ; done
+          for i in "${backup_files[@]}" ; do mv "$i"  /tmp/backup ; done
           rm -rf ..?* .[!.]* *
-          for i in $backup_files ; do mv  /tmp/backup/$i  .  ; done
+          for i in "${backup_files[@]}" ; do mv  "/tmp/backup/$i"  .  ; done
           rm -rf /tmp/backup
+          ls .
           touch venv  # disable venv target
 
       - name: run tests

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -40,9 +40,9 @@ jobs:
         run: |
           export backup_files=( tests examples .env_file makefile )
           mkdir /tmp/backup
-          for i in $backup_files[@] ; do mv $i  /tmp/backup ; done
+          for i in $backup_files; do mv $i  /tmp/backup ; done
           rm -rf ..?* .[!.]* *
-          for i in $backup_files[@] ; do mv  /tmp/backup/$i  .  ; done
+          for i in $backup_files ; do mv  /tmp/backup/$i  .  ; done
           rm -rf /tmp/backup
           touch venv  # disable venv target
 

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -38,13 +38,12 @@ jobs:
 
       - name: prepare testing environment
         run: |
-          mkdir /tmp/testing_files
-          cp -r tests /tmp/testing_files
-          cp -r examples /tmp/testing_files
-          cp .env_file /tmp/testing_files
-          cp makefile /tmp/testing_files
-          rm -r ./*
-          cp -r /tmp/testing_files/* .
+          export backup_files=( tests examples .env_file makefile )
+          mkdir /tmp/backup
+          for i in $backup_files[@] ; do mv $i  /tmp/backup ; done
+          rm -rf ..?* .[!.]* *
+          for i in $backup_files[@] ; do mv  /tmp/backup/$i  .  ; done
+          rm -rf /tmp/backup
           touch venv  # disable venv target
 
       - name: run tests

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -44,7 +44,6 @@ jobs:
           rm -rf ..?* .[!.]* *
           for i in "${backup_files[@]}" ; do mv  "/tmp/backup/$i"  .  ; done
           rm -rf /tmp/backup
-          ls .
           touch venv  # disable venv target
 
       - name: run tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include CONTRIBUTING.md
 include LICENSE
 include README.md
-include dff/context_storages/db/protocols.json
+include dff/context_storages/protocols.json
 
 exclude makefile
 

--- a/makefile
+++ b/makefile
@@ -28,12 +28,6 @@ venv:
 	pip install --upgrade pip
 	pip install -e .[devel_full]
 
-venv_test:
-	@echo "Start creating virtual environment (test)"
-	$(PYTHON) -m venv $(VENV_PATH)
-	pip install --upgrade pip
-	pip install -e .[test_full]
-
 format: venv
 	black --line-length=120 --exclude='venv|build|examples' .
 	black --line-length=100 examples


### PR DESCRIPTION
# Description

Currently the tests are run with the dff directory inside the testing environment. The first commit makes the following changes to the workflow `test_coverage`:

- venv is no longer created (this is unnecessary)
- DFF is installed by first building a wheel (I don't think this is necesary, could replace it with `python -m pip install .[test_full]`)
- All files in the testing directory are removed except for `tests/`, `examples/`, `.env_file`, `makefile`

The second commit fixes an issue that was found with this change.

# Checklist

- [ ] I have covered the code with tests
- [x] I have added comments to my code to help others understand it
- [ ] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes