### PR TITLE
docs: fix `ModuleName` in docs

### DIFF
--- a/dff/script/core/types.py
+++ b/dff/script/core/types.py
@@ -3,7 +3,7 @@ Types
 ---------------------------
 Basic types are defined here.
 """
-from typing import Union, Callable, Tuple
+from typing import Union, Callable, Tuple, AnyStr
 from enum import Enum, auto
 from typing_extensions import TypeAlias
 
@@ -30,7 +30,7 @@ NodeLabelType: TypeAlias = Union[Callable, NodeLabelTupledType, str]
 ConditionType: TypeAlias = Callable
 """Condition type can be only `Callable`."""
 
-ModuleName: TypeAlias = str
+ModuleName: TypeAlias = AnyStr
 """
 Module name names addon state, or your own module state. For example module name can be `"dff_context_storages"`.
 """

--- a/dff/script/core/types.py
+++ b/dff/script/core/types.py
@@ -3,7 +3,7 @@ Types
 ---------------------------
 Basic types are defined here.
 """
-from typing import Union, Callable, Tuple, AnyStr
+from typing import Union, Callable, Tuple
 from enum import Enum, auto
 from typing_extensions import TypeAlias
 
@@ -30,7 +30,7 @@ NodeLabelType: TypeAlias = Union[Callable, NodeLabelTupledType, str]
 ConditionType: TypeAlias = Callable
 """Condition type can be only `Callable`."""
 
-ModuleName: TypeAlias = AnyStr
+ModuleName: TypeAlias = "str"
 """
 Module name names addon state, or your own module state. For example module name can be `"dff_context_storages"`.
 """


### PR DESCRIPTION
# Description

As mentioned [here](https://github.com/deeppavlov/dialog_flow_framework/pull/56#issue-1506230248) `TypeAlias` did not help with displaying `ModuleName` properly in documentation. This PR fixes the issue with docs (see attachments) and doesn't produce [typing errors](https://github.com/deeppavlov/dialog_flow_framework/pull/45#pullrequestreview-1215401813).
![Screenshot_20221221_191525](https://user-images.githubusercontent.com/61429541/208957540-bc10950b-5448-48c5-ad71-27b5c0b9e221.png)

# Checklist

- [x] I have covered the code with tests
- [x] I have added comments to my code to help others understand it
- [x] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes