### PR TITLE
add kwargs to `Pipeline.from_script`

### DIFF
--- a/dff/pipeline/pipeline/pipeline.py
+++ b/dff/pipeline/pipeline/pipeline.py
@@ -154,6 +154,7 @@ class Pipeline:
         messenger_interface: Optional[MessengerInterface] = None,
         pre_services: Optional[List[Union[ServiceBuilder, ServiceGroupBuilder]]] = None,
         post_services: Optional[List[Union[ServiceBuilder, ServiceGroupBuilder]]] = None,
+        **kwargs,
     ):
         """
         Pipeline script-based constructor.
@@ -176,8 +177,9 @@ class Pipeline:
             :py:data:`~.ServiceGroupBuilder` that will be executed after Actor.
             It constructs root service group by merging `pre_services` + actor + `post_services`.
         :type post_services: Optional[List[Union[ServiceBuilder, ServiceGroupBuilder]]]
+        :param kwargs: Keyword arguments to pass to :py:meth:`dff.script.core.actor.Actor.__init__`
         """
-        actor = Actor(script, start_label, fallback_label)
+        actor = Actor(script, start_label, fallback_label, **kwargs)
         pre_services = [] if pre_services is None else pre_services
         post_services = [] if post_services is None else post_services
         return cls(

--- a/tests/pipeline/test_pipeline_creation.py
+++ b/tests/pipeline/test_pipeline_creation.py
@@ -5,27 +5,12 @@ from dff.script.core.keywords import RESPONSE, TRANSITIONS
 import dff.script.conditions as cnd
 
 
-@pytest.mark.parametrize(
-    "validation",
-    (
-        True,
-        False
-    )
-)
+@pytest.mark.parametrize("validation", (True, False))
 def test_from_script_with_validation(validation):
     def response(ctx, actor):
         raise RuntimeError()
 
-    script = {
-        "": {
-            "": {
-                RESPONSE: response,
-                TRANSITIONS: {
-                    "": cnd.true()
-                }
-            }
-        }
-    }
+    script = {"": {"": {RESPONSE: response, TRANSITIONS: {"": cnd.true()}}}}
 
     if validation:
         with pytest.raises(ValueError):

--- a/tests/pipeline/test_pipeline_creation.py
+++ b/tests/pipeline/test_pipeline_creation.py
@@ -1,0 +1,34 @@
+import pytest
+
+from dff.pipeline import Pipeline
+from dff.script.core.keywords import RESPONSE, TRANSITIONS
+import dff.script.conditions as cnd
+
+
+@pytest.mark.parametrize(
+    "validation",
+    (
+        True,
+        False
+    )
+)
+def test_from_script_with_validation(validation):
+    def response(ctx, actor):
+        raise RuntimeError()
+
+    script = {
+        "": {
+            "": {
+                RESPONSE: response,
+                TRANSITIONS: {
+                    "": cnd.true()
+                }
+            }
+        }
+    }
+
+    if validation:
+        with pytest.raises(ValueError):
+            _ = Pipeline.from_script(script=script, start_label=("", ""), validation_stage=validation)
+    else:
+        _ = Pipeline.from_script(script=script, start_label=("", ""), validation_stage=validation)


### PR DESCRIPTION
# Description

Add the ability to specify keywords in `Pipeline.from_script` to be passed to `Actor.__init__`.
This allows to skip validation:
```
pipeline = Pipeline.from_script(
    script=script,
    start_label=("flow", "start_node"),
    fallback_label=("flow", "fallback_node"),
    validation_stage=False,
)
```

# Checklist

- [x] I have covered the code with tests
- [ ] I have added comments to my code to help others understand it
- [x] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes