### PR TITLE
`id-token` permission write added

### DIFF
--- a/.github/workflows/build_and_publish_docs.yml
+++ b/.github/workflows/build_and_publish_docs.yml
@@ -18,6 +18,9 @@ jobs:
   publish:
     name: build and publish docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
# Description

GitHub actions workflow kindly asked me to add `id-token: 'write'` permission to `build_and_publish_docs` action. So I did.

# Checklist

- [ ] I have covered the code with tests
- [ ] I have added comments to my code to help others understand it
- [x] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes