### PR TITLE
disabled test coverage on non-linux machines

### DIFF
--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -47,5 +47,5 @@ jobs:
           if [ "$RUNNER_OS" == "Linux" ]; then
               source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /')
           fi
-          pytest --tb=long -vv --cache-clear --cov=dff tests/
+          pytest --tb=long -vv --cache-clear --no-cov tests/
         shell: bash


### PR DESCRIPTION
# Description

Fixes workflow hanging on pytest coverage on windows.

# Checklist

- [x] I have covered the code with tests
- [x] I have added comments to my code to help others understand it
- [x] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes