### PR TITLE
`ydb` dependency lowered

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ postgresql_dependencies = merge_req_lists(
 )
 
 ydb_dependencies = [
-    "ydb>=2.5.0",
+    "ydb~=2.5.0",
     "six>=1.16.0",
 ]
 


### PR DESCRIPTION
# Description

YDB dependency version fixed.
Today the new **major** version of `ydb` package was released, where python3.7 support was dropped.

WARNING!!!
That's not the solution for the problem!  
Random bugs like this one **will** appear **constantly** untill we change our approach towards dependencies.  
I suggest using [compatible dependencies syntax](https://peps.python.org/pep-0440/#compatible-release) instead.  
Basically the syntax was designed specifically for our case: it will allow picking the latest _compatible_ package version.

# Checklist

- [x] I have covered the code with tests
- [x] I have added comments to my code to help others understand it
- [x] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes