### PR TITLE
Pipeline doc improvements

### DIFF
--- a/dff/pipeline/pipeline/component.py
+++ b/dff/pipeline/pipeline/component.py
@@ -83,7 +83,8 @@ class PipelineComponent(abc.ABC):
         #: Component name (should be unique in single :py:class:`~pipeline.service.group.ServiceGroup`),
         #: should not be blank or contain '.' symbol.
         self.name = name
-        #: Вot-separated path to component (should be is universally unique).
+        #: Dot-separated path to component (is universally unique).
+        #: This attribute is set in :py:func:`~dff.pipeline.pipeline.utils.finalize_service_group`.
         self.path = path
 
         self.before_handler = BeforeHandler([] if before_handler is None else before_handler)

--- a/dff/pipeline/pipeline/component.py
+++ b/dff/pipeline/pipeline/component.py
@@ -70,22 +70,30 @@ class PipelineComponent(abc.ABC):
         name: Optional[str] = None,
         path: Optional[str] = None,
     ):
-        #: Maximum component execution time (in seconds),
-        #: if it exceeds this time, it is interrupted (for asynchronous only!).
         self.timeout = timeout
-        #: Requested asynchronous property; if not defined, :py:attr:`~requested_async_flag` is used instead.
+        """
+        Maximum component execution time (in seconds),
+        if it exceeds this time, it is interrupted (for asynchronous only!).
+        """
         self.requested_async_flag = requested_async_flag
-        #: Calculated asynchronous property, whether the component can be asynchronous or not.
+        """Requested asynchronous property; if not defined, :py:attr:`~requested_async_flag` is used instead."""
         self.calculated_async_flag = calculated_async_flag
-        #: Component start condition that is invoked before each component execution;
-        #: component is executed only if it returns `True`.
+        """Calculated asynchronous property, whether the component can be asynchronous or not."""
         self.start_condition = always_start_condition if start_condition is None else start_condition
-        #: Component name (should be unique in single :py:class:`~pipeline.service.group.ServiceGroup`),
-        #: should not be blank or contain '.' symbol.
+        """
+        Component start condition that is invoked before each component execution;
+        component is executed only if it returns `True`.
+        """
         self.name = name
-        #: Dot-separated path to component (is universally unique).
-        #: This attribute is set in :py:func:`~dff.pipeline.pipeline.utils.finalize_service_group`.
+        """
+        Component name (should be unique in single :py:class:`~pipeline.service.group.ServiceGroup`),
+        should not be blank or contain '.' symbol.
+        """
         self.path = path
+        """
+        Dot-separated path to component (is universally unique).
+        This attribute is set in :py:func:`~dff.pipeline.pipeline.utils.finalize_service_group`.
+        """
 
         self.before_handler = BeforeHandler([] if before_handler is None else before_handler)
         self.after_handler = AfterHandler([] if after_handler is None else after_handler)

--- a/dff/pipeline/pipeline/utils.py
+++ b/dff/pipeline/pipeline/utils.py
@@ -101,6 +101,9 @@ def finalize_service_group(service_group: ServiceGroup, path: str = ".") -> bool
     It also searches for "ACTOR" in the group, throwing exception if no actor or multiple actors found.
 
     :param service_group: Service group to resolve name collisions in.
+    :param path:
+        A prefix for component paths -- path of `component` is equal to `{path}.{component.name}`.
+        Defaults to ".".
     """
     actor = False
     names_counter = collections.Counter([component.name for component in service_group.components])

--- a/dff/pipeline/service/extra.py
+++ b/dff/pipeline/service/extra.py
@@ -13,7 +13,13 @@ from typing import Optional, List, ForwardRef
 from dff.script import Context
 
 from .utils import collect_defined_constructor_parameters_to_dict, _get_attrs_with_updates, wrap_sync_function_in_async
-from ..types import ServiceRuntimeInfo, ExtraHandlerType, ExtraHandlerBuilder, ExtraHandlerFunction
+from ..types import (
+    ServiceRuntimeInfo,
+    ExtraHandlerType,
+    ExtraHandlerBuilder,
+    ExtraHandlerFunction,
+    ExtraHandlerRuntimeInfo,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,16 +101,12 @@ class _ComponentExtraHandler:
         elif handler_params == 2:
             await wrap_sync_function_in_async(function, ctx, pipeline)
         elif handler_params == 3:
-            await wrap_sync_function_in_async(
-                function,
-                ctx,
-                pipeline,
-                {
-                    "function": function,
-                    "stage": self.stage,
-                    "component": component_info,
-                },
-            )
+            extra_handler_runtime_info: ExtraHandlerRuntimeInfo = {
+                "function": function,
+                "stage": self.stage,
+                "component": component_info,
+            }
+            await wrap_sync_function_in_async(function, ctx, pipeline, extra_handler_runtime_info)
         else:
             raise Exception(
                 f"Too many parameters required for component {component_info['name']} {self.stage.name}"


### PR DESCRIPTION
# Description

This PR makes pipeline documentation more clear:
- Explicitly declare type for `ExtraHandlerRuntimeInfo` object (this allows searching for usages of this class inside the codebase).
- Add an explanation for when `PipelineComponent.path` attribute is set.
- Add documentation for `path` parameter of the `finalize_service_group` function.