### PR TITLE
Add TOY_SCRIPT_ARGS

### DIFF
--- a/dff/utils/testing/__init__.py
+++ b/dff/utils/testing/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa: F401
 from .common import is_interactive_mode, check_happy_path, run_interactive_mode
-from .toy_script import TOY_SCRIPT, HAPPY_PATH
+from .toy_script import TOY_SCRIPT, TOY_SCRIPT_ARGS, HAPPY_PATH
 from .response_comparers import default_comparer
 
 try:

--- a/dff/utils/testing/toy_script.py
+++ b/dff/utils/testing/toy_script.py
@@ -34,6 +34,8 @@ TOY_SCRIPT = {
 }
 """
 An example of a simple script.
+
+:meta hide-value:
 """
 
 HAPPY_PATH = (
@@ -45,4 +47,6 @@ HAPPY_PATH = (
 )
 """
 An example of a simple dialog.
+
+:meta hide-value:
 """

--- a/dff/utils/testing/toy_script.py
+++ b/dff/utils/testing/toy_script.py
@@ -38,6 +38,18 @@ An example of a simple script.
 :meta hide-value:
 """
 
+TOY_SCRIPT_ARGS = (TOY_SCRIPT, ("greeting_flow", "start_node"), ("greeting_flow", "fallback_node"))
+"""
+Arguments to pass to :py:meth:`~dff.pipeline.pipeline.pipeline.Pipeline.from_script` in order to
+use :py:data:`~.TOY_SCRIPT`:
+
+.. code-block::
+
+    Pipeline.from_script(*TOY_SCRIPT_ARGS, context_storage=..., ...)
+
+:meta hide-value:
+"""
+
 HAPPY_PATH = (
     (Message(text="Hi"), Message(text="Hi, how are you?")),
     (Message(text="i'm fine, how are you?"), Message(text="Good. What do you want to talk about?")),

--- a/tests/context_storages/test_dbs.py
+++ b/tests/context_storages/test_dbs.py
@@ -33,7 +33,7 @@ from dff.utils.testing.cleanup_db import (
 
 from tests.test_utils import get_path_from_tests_to_current_dir
 from dff.pipeline import Pipeline
-from dff.utils.testing import check_happy_path, TOY_SCRIPT, HAPPY_PATH
+from dff.utils.testing import check_happy_path, TOY_SCRIPT_ARGS, HAPPY_PATH
 
 dot_path_to_addon = get_path_from_tests_to_current_dir(__file__, separator=".")
 
@@ -81,12 +81,7 @@ def generic_test(db, testing_context, context_id):
     assert context_id not in db
     # test `get` method
     assert db.get(context_id) is None
-    pipeline = Pipeline.from_script(
-        TOY_SCRIPT,
-        context_storage=db,
-        start_label=("greeting_flow", "start_node"),
-        fallback_label=("greeting_flow", "fallback_node"),
-    )
+    pipeline = Pipeline.from_script(*TOY_SCRIPT_ARGS, context_storage=db)
     check_happy_path(pipeline, happy_path=HAPPY_PATH)
 
 

--- a/tutorials/context_storages/1_basics.py
+++ b/tutorials/context_storages/1_basics.py
@@ -17,19 +17,14 @@ from dff.utils.testing.common import (
     is_interactive_mode,
     run_interactive_mode,
 )
-from dff.utils.testing.toy_script import TOY_SCRIPT, HAPPY_PATH
+from dff.utils.testing.toy_script import TOY_SCRIPT_ARGS, HAPPY_PATH
 
 pathlib.Path("dbs").mkdir(exist_ok=True)
 db = context_storage_factory("json://dbs/file.json")
 # db = context_storage_factory("pickle://dbs/file.pkl")
 # db = context_storage_factory("shelve://dbs/file")
 
-pipeline = Pipeline.from_script(
-    TOY_SCRIPT,
-    context_storage=db,
-    start_label=("greeting_flow", "start_node"),
-    fallback_label=("greeting_flow", "fallback_node"),
-)
+pipeline = Pipeline.from_script(*TOY_SCRIPT_ARGS, context_storage=db)
 
 if __name__ == "__main__":
     check_happy_path(pipeline, HAPPY_PATH)

--- a/tutorials/context_storages/2_postgresql.py
+++ b/tutorials/context_storages/2_postgresql.py
@@ -17,7 +17,7 @@ from dff.utils.testing.common import (
     is_interactive_mode,
     run_interactive_mode,
 )
-from dff.utils.testing.toy_script import TOY_SCRIPT, HAPPY_PATH
+from dff.utils.testing.toy_script import TOY_SCRIPT_ARGS, HAPPY_PATH
 
 
 # %%
@@ -29,12 +29,7 @@ db_uri = "postgresql+asyncpg://{}:{}@localhost:5432/{}".format(
 db = context_storage_factory(db_uri)
 
 
-pipeline = Pipeline.from_script(
-    TOY_SCRIPT,
-    context_storage=db,
-    start_label=("greeting_flow", "start_node"),
-    fallback_label=("greeting_flow", "fallback_node"),
-)
+pipeline = Pipeline.from_script(*TOY_SCRIPT_ARGS, context_storage=db)
 
 
 # %%

--- a/tutorials/context_storages/3_mongodb.py
+++ b/tutorials/context_storages/3_mongodb.py
@@ -17,7 +17,7 @@ from dff.utils.testing.common import (
     is_interactive_mode,
     run_interactive_mode,
 )
-from dff.utils.testing.toy_script import TOY_SCRIPT, HAPPY_PATH
+from dff.utils.testing.toy_script import TOY_SCRIPT_ARGS, HAPPY_PATH
 
 
 # %%
@@ -28,12 +28,7 @@ db_uri = "mongodb://{}:{}@localhost:27017/{}".format(
 )
 db = context_storage_factory(db_uri)
 
-pipeline = Pipeline.from_script(
-    TOY_SCRIPT,
-    context_storage=db,
-    start_label=("greeting_flow", "start_node"),
-    fallback_label=("greeting_flow", "fallback_node"),
-)
+pipeline = Pipeline.from_script(*TOY_SCRIPT_ARGS, context_storage=db)
 
 
 # %%

--- a/tutorials/context_storages/4_redis.py
+++ b/tutorials/context_storages/4_redis.py
@@ -17,7 +17,7 @@ from dff.utils.testing.common import (
     is_interactive_mode,
     run_interactive_mode,
 )
-from dff.utils.testing.toy_script import TOY_SCRIPT, HAPPY_PATH
+from dff.utils.testing.toy_script import TOY_SCRIPT_ARGS, HAPPY_PATH
 
 
 # %%
@@ -25,12 +25,7 @@ db_uri = "redis://{}:{}@localhost:6379/{}".format("", os.getenv("REDIS_PASSWORD"
 db = context_storage_factory(db_uri)
 
 
-pipeline = Pipeline.from_script(
-    TOY_SCRIPT,
-    context_storage=db,
-    start_label=("greeting_flow", "start_node"),
-    fallback_label=("greeting_flow", "fallback_node"),
-)
+pipeline = Pipeline.from_script(*TOY_SCRIPT_ARGS, context_storage=db)
 
 
 # %%

--- a/tutorials/context_storages/5_mysql.py
+++ b/tutorials/context_storages/5_mysql.py
@@ -17,7 +17,7 @@ from dff.utils.testing.common import (
     is_interactive_mode,
     run_interactive_mode,
 )
-from dff.utils.testing.toy_script import TOY_SCRIPT, HAPPY_PATH
+from dff.utils.testing.toy_script import TOY_SCRIPT_ARGS, HAPPY_PATH
 
 
 # %%
@@ -29,12 +29,7 @@ db_uri = "mysql+asyncmy://{}:{}@localhost:3307/{}".format(
 db = context_storage_factory(db_uri)
 
 
-pipeline = Pipeline.from_script(
-    TOY_SCRIPT,
-    context_storage=db,
-    start_label=("greeting_flow", "start_node"),
-    fallback_label=("greeting_flow", "fallback_node"),
-)
+pipeline = Pipeline.from_script(*TOY_SCRIPT_ARGS, context_storage=db)
 
 
 # %%

--- a/tutorials/context_storages/6_sqlite.py
+++ b/tutorials/context_storages/6_sqlite.py
@@ -18,7 +18,7 @@ from dff.utils.testing.common import (
     is_interactive_mode,
     run_interactive_mode,
 )
-from dff.utils.testing.toy_script import TOY_SCRIPT, HAPPY_PATH
+from dff.utils.testing.toy_script import TOY_SCRIPT_ARGS, HAPPY_PATH
 
 
 # %%
@@ -31,12 +31,7 @@ db_uri = f"sqlite+aiosqlite:{separator}{db_file.absolute()}"
 db = context_storage_factory(db_uri)
 
 
-pipeline = Pipeline.from_script(
-    TOY_SCRIPT,
-    context_storage=db,
-    start_label=("greeting_flow", "start_node"),
-    fallback_label=("greeting_flow", "fallback_node"),
-)
+pipeline = Pipeline.from_script(*TOY_SCRIPT_ARGS, context_storage=db)
 
 
 # %%

--- a/tutorials/context_storages/7_yandex_database.py
+++ b/tutorials/context_storages/7_yandex_database.py
@@ -17,7 +17,7 @@ from dff.utils.testing.common import (
     run_interactive_mode,
     is_interactive_mode,
 )
-from dff.utils.testing.toy_script import TOY_SCRIPT, HAPPY_PATH
+from dff.utils.testing.toy_script import TOY_SCRIPT_ARGS, HAPPY_PATH
 
 
 # %%
@@ -35,12 +35,7 @@ db_uri = "{}{}".format(
 )
 db = context_storage_factory(db_uri)
 
-pipeline = Pipeline.from_script(
-    TOY_SCRIPT,
-    context_storage=db,
-    start_label=("greeting_flow", "start_node"),
-    fallback_label=("greeting_flow", "fallback_node"),
-)
+pipeline = Pipeline.from_script(*TOY_SCRIPT_ARGS, context_storage=db)
 
 
 # %%

--- a/tutorials/context_storages/8_json_storage_with_web_api.py
+++ b/tutorials/context_storages/8_json_storage_with_web_api.py
@@ -13,7 +13,7 @@ from dff.context_storages import context_storage_factory
 
 from dff.pipeline import Pipeline
 from dff.utils.testing.common import check_happy_path, is_interactive_mode
-from dff.utils.testing.toy_script import TOY_SCRIPT, HAPPY_PATH
+from dff.utils.testing.toy_script import TOY_SCRIPT_ARGS, HAPPY_PATH
 
 from flask import Flask, request
 
@@ -34,12 +34,7 @@ def respond():
 
 
 # %%
-pipeline = Pipeline.from_script(
-    TOY_SCRIPT,
-    context_storage=db,
-    start_label=("greeting_flow", "start_node"),
-    fallback_label=("greeting_flow", "fallback_node"),
-)
+pipeline = Pipeline.from_script(*TOY_SCRIPT_ARGS, context_storage=db)
 
 
 # %%

--- a/tutorials/messengers/telegram/7_polling_setup.py
+++ b/tutorials/messengers/telegram/7_polling_setup.py
@@ -14,7 +14,7 @@ from dff.messengers.telegram.interface import PollingTelegramInterface
 from dff.pipeline import Pipeline
 
 from dff.utils.testing.common import is_interactive_mode
-from dff.utils.testing.toy_script import TOY_SCRIPT, HAPPY_PATH
+from dff.utils.testing.toy_script import TOY_SCRIPT_ARGS, HAPPY_PATH
 from telebot.util import update_types
 
 
@@ -46,9 +46,7 @@ happy_path = HAPPY_PATH
 
 # %%
 pipeline = Pipeline.from_script(
-    script=TOY_SCRIPT,
-    start_label=("greeting_flow", "start_node"),
-    fallback_label=("greeting_flow", "fallback_node"),
+    *TOY_SCRIPT_ARGS,
     messenger_interface=interface,  # The interface can be passed as a pipeline argument.
 )
 

--- a/tutorials/messengers/telegram/8_webhook_setup.py
+++ b/tutorials/messengers/telegram/8_webhook_setup.py
@@ -14,7 +14,7 @@ from dff.messengers.telegram import (
     CallbackTelegramInterface,
 )
 from dff.pipeline import Pipeline
-from dff.utils.testing.toy_script import TOY_SCRIPT, HAPPY_PATH
+from dff.utils.testing.toy_script import TOY_SCRIPT_ARGS, HAPPY_PATH
 from dff.utils.testing.common import is_interactive_mode
 
 
@@ -39,9 +39,7 @@ interface = CallbackTelegramInterface(token=os.getenv("TG_BOT_TOKEN", ""))
 
 # %%
 pipeline = Pipeline.from_script(
-    script=TOY_SCRIPT,
-    start_label=("greeting_flow", "start_node"),
-    fallback_label=("greeting_flow", "fallback_node"),
+    *TOY_SCRIPT_ARGS,
     messenger_interface=interface,  # The interface can be passed as a pipeline argument.
 )
 

--- a/tutorials/pipeline/1_basics.py
+++ b/tutorials/pipeline/1_basics.py
@@ -12,7 +12,13 @@ from dff.script import Context
 
 from dff.pipeline import Pipeline
 
-from dff.utils.testing import check_happy_path, is_interactive_mode, HAPPY_PATH, TOY_SCRIPT
+from dff.utils.testing import (
+    check_happy_path,
+    is_interactive_mode,
+    HAPPY_PATH,
+    TOY_SCRIPT,
+    TOY_SCRIPT_ARGS,
+)
 
 
 # %% [markdown]
@@ -42,6 +48,19 @@ pipeline = Pipeline.from_script(
     TOY_SCRIPT,  # Pipeline script object, defined in `dff.utils.testing.toy_script`.
     start_label=("greeting_flow", "start_node"),
     fallback_label=("greeting_flow", "fallback_node"),
+)
+
+
+# %% [markdown]
+"""
+For the sake of brevity, other tutorials might use `TOY_SCRIPT_ARGS` to initialize pipeline:
+"""
+
+# %%
+assert TOY_SCRIPT_ARGS == (
+    TOY_SCRIPT,
+    ("greeting_flow", "start_node"),
+    ("greeting_flow", "fallback_node"),
 )
 
 

--- a/tutorials/pipeline/2_pre_and_post_processors.py
+++ b/tutorials/pipeline/2_pre_and_post_processors.py
@@ -15,7 +15,7 @@ from dff.script import Context
 
 from dff.pipeline import Pipeline
 
-from dff.utils.testing import check_happy_path, is_interactive_mode, HAPPY_PATH, TOY_SCRIPT
+from dff.utils.testing import check_happy_path, is_interactive_mode, HAPPY_PATH, TOY_SCRIPT_ARGS
 
 logger = logging.getLogger(__name__)
 
@@ -57,9 +57,7 @@ def pong_processor(ctx: Context):
 
 # %%
 pipeline = Pipeline.from_script(
-    TOY_SCRIPT,
-    ("greeting_flow", "start_node"),
-    ("greeting_flow", "fallback_node"),
+    *TOY_SCRIPT_ARGS,
     context_storage={},  # `context_storage` - a dictionary or
     # a `DBContextStorage` instance,
     # a place to store dialog contexts


### PR DESCRIPTION
# Description

This PR adds `TOY_SCRIPT_ARGS` for tutorials to use instead of specifying `start_label` and `fallback_label` and changes existing tutorials to use it.
Tutorials using `Pipeline.from_dict` are left unchanged. It is possible to also include them by changing `TOY_SCRIPT_ARGS` to `TOY_SCRIPT_KWARGS` if necessary.

Also this PR hides value of consts defined in `dff/utils/testing/toy_script.py` from documentation (without `:meta hide-value:` the documentation contains the entire `TOY_SCRIPT`)

# Checklist

- [ ] I have covered the code with tests
- [x] I have added comments to my code to help others understand it
- [x] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes