### PR TITLE
Pipeline typing improvement

### DIFF
--- a/dff/pipeline/pipeline/pipeline.py
+++ b/dff/pipeline/pipeline/pipeline.py
@@ -212,7 +212,7 @@ class Pipeline:
         messenger_interface: Optional[MessengerInterface] = None,
         pre_services: Optional[List[Union[ServiceBuilder, ServiceGroupBuilder]]] = None,
         post_services: Optional[List[Union[ServiceBuilder, ServiceGroupBuilder]]] = None,
-    ):
+    ) -> "Pipeline":
         """
         Pipeline script-based constructor.
         It creates :py:class:`~.Actor` object and wraps it with pipeline.

--- a/dff/pipeline/types.py
+++ b/dff/pipeline/types.py
@@ -17,6 +17,7 @@ from typing_extensions import NotRequired, TypedDict, TypeAlias
 _ForwardPipeline = NewType("Pipeline", None)
 _ForwardPipelineComponent = NewType("PipelineComponent", None)
 _ForwardService = NewType("Service", _ForwardPipelineComponent)
+_ForwardServiceBuilder = NewType("ServiceBuilder", None)
 _ForwardServiceGroup = NewType("ServiceGroup", _ForwardPipelineComponent)
 _ForwardComponentExtraHandler = NewType("_ComponentExtraHandler", None)
 _ForwardProvider = NewType("ABCProvider", ABC)
@@ -193,7 +194,7 @@ ServiceBuilder: TypeAlias = Union[
     TypedDict(
         "ServiceDict",
         {
-            "handler": "ServiceBuilder",
+            "handler": _ForwardServiceBuilder,
             "before_handler": NotRequired[Optional[ExtraHandlerBuilder]],
             "after_handler": NotRequired[Optional[ExtraHandlerBuilder]],
             "timeout": NotRequired[Optional[float]],


### PR DESCRIPTION
# Description

- Add return type for `Pipeline.from_script`.
- Replace string annotation of `ServiceBuilder` with a `_Forward` annotation. This is done because PyCharm doesn't load documentation for any method accepting `ServiceBuilder` as an argument.