### PR TITLE
Replace `isinstance(..., Callable)` with `callable(...)`

### DIFF
--- a/dff/pipeline/pipeline/actor.py
+++ b/dff/pipeline/pipeline/actor.py
@@ -289,7 +289,7 @@ class Actor:
         true_labels = []
         for label, condition in transitions.items():
             if self.condition_handler(condition, ctx, pipeline, *args, **kwargs):
-                if isinstance(label, Callable):
+                if callable(label):
                     label = label(ctx, pipeline, *args, **kwargs)
                     # TODO: explicit handling of errors
                     if label is None:
@@ -340,7 +340,7 @@ class Actor:
             ctx.validation = True
             ctx.add_request(Message(text="text"))
 
-            label = label(ctx, pipeline) if isinstance(label, Callable) else normalize_label(label, flow_label)
+            label = label(ctx, pipeline) if callable(label) else normalize_label(label, flow_label)
 
             # validate labeling
             try:

--- a/dff/pipeline/pipeline/utils.py
+++ b/dff/pipeline/pipeline/utils.py
@@ -5,7 +5,7 @@ The Utils module contains several service functions that are commonly used throu
 These functions provide a variety of utility functionality.
 """
 import collections
-from typing import Union, List, Callable
+from typing import Union, List
 from inspect import isfunction
 
 from ..service.service import Service
@@ -77,7 +77,7 @@ def rename_component_incrementing(
     """
     if isinstance(service, Service) and isinstance(service.handler, str) and service.handler == "ACTOR":
         base_name = "actor"
-    elif isinstance(service, Service) and isinstance(service.handler, Callable):
+    elif isinstance(service, Service) and callable(service.handler):
         if isfunction(service.handler):
             base_name = service.handler.__name__
         else:

--- a/dff/pipeline/service/service.py
+++ b/dff/pipeline/service/service.py
@@ -14,7 +14,7 @@ Actor wrapping service can be synchronous only.
 import logging
 import asyncio
 import inspect
-from typing import Optional, Callable, ForwardRef
+from typing import Optional, ForwardRef
 
 from dff.script import Context
 
@@ -85,7 +85,7 @@ class Service(PipelineComponent):
                     overridden_parameters,
                 )
             )
-        elif isinstance(handler, Callable) or isinstance(handler, str) and handler == "ACTOR":
+        elif callable(handler) or isinstance(handler, str) and handler == "ACTOR":
             self.handler = handler
             super(Service, self).__init__(
                 before_handler,
@@ -190,7 +190,7 @@ class Service(PipelineComponent):
         representation = super(Service, self).info_dict
         if isinstance(self.handler, str) and self.handler == "ACTOR":
             service_representation = "Instance of Actor"
-        elif isinstance(self.handler, Callable):
+        elif callable(self.handler):
             service_representation = f"Callable '{self.handler.__name__}'"
         else:
             service_representation = "[Unknown]"

--- a/dff/script/conditions/std_conditions.py
+++ b/dff/script/conditions/std_conditions.py
@@ -83,7 +83,7 @@ def check_cond_seq(cond_seq: list):
     :param cond_seq: List of conditions to check.
     """
     for cond in cond_seq:
-        if not isinstance(cond, Callable):
+        if not callable(cond):
             raise TypeError(f"{cond_seq} has to consist of callable objects")
 
 

--- a/dff/script/core/normalization.py
+++ b/dff/script/core/normalization.py
@@ -33,7 +33,7 @@ def normalize_label(label: NodeLabelType, default_flow_label: LabelType = "") ->
     :return: Result of the label normalization,
         if Callable is returned, the normalized result is returned.
     """
-    if isinstance(label, Callable):
+    if callable(label):
 
         def get_label_handler(ctx: Context, pipeline: Pipeline, *args, **kwargs) -> NodeLabel3Type:
             try:
@@ -69,7 +69,7 @@ def normalize_condition(condition: ConditionType) -> Callable:
     :param condition: Condition to normalize.
     :return: The function condition wrapped into the try/except.
     """
-    if isinstance(condition, Callable):
+    if callable(condition):
 
         def callable_condition_handler(ctx: Context, pipeline: Pipeline, *args, **kwargs) -> bool:
             try:
@@ -104,7 +104,7 @@ def normalize_response(response: Optional[Union[Message, Callable[..., Message]]
     :param response: Response to normalize.
     :return: Function that returns callable response.
     """
-    if isinstance(response, Callable):
+    if callable(response):
         return response
     else:
         if response is None:

--- a/tests/script/core/test_normalization.py
+++ b/tests/script/core/test_normalization.py
@@ -1,5 +1,5 @@
 # %%
-from typing import Callable, Tuple
+from typing import Tuple
 
 from dff.pipeline import Pipeline
 from dff.script import (
@@ -49,7 +49,7 @@ def test_normalize_label():
         return ("flow", "node2", 1)
 
     n_f = normalize_label(true_label_func)
-    assert isinstance(n_f, Callable)
+    assert callable(n_f)
     assert n_f(ctx, actor) == ("flow", "node1", 1)
     n_f = normalize_label(false_label_func)
     assert n_f(ctx, actor) is None
@@ -70,25 +70,25 @@ def test_normalize_condition():
         raise Exception("False condition")
 
     n_f = normalize_condition(true_condition_func)
-    assert isinstance(n_f, Callable)
+    assert callable(n_f)
     flag = n_f(ctx, actor)
     assert isinstance(flag, bool) and flag
     n_f = normalize_condition(false_condition_func)
     flag = n_f(ctx, actor)
     assert isinstance(flag, bool) and not flag
 
-    assert isinstance(normalize_condition(std_func), Callable)
+    assert callable(normalize_condition(std_func))
 
 
 def test_normalize_transitions():
     trans = normalize_transitions({("flow", "node", 1.0): std_func})
     assert list(trans)[0] == ("flow", "node", 1.0)
-    assert isinstance(list(trans.values())[0], Callable)
+    assert callable(list(trans.values())[0])
 
 
 def test_normalize_response():
-    assert isinstance(normalize_response(std_func), Callable)
-    assert isinstance(normalize_response(Message(text="text")), Callable)
+    assert callable(normalize_response(std_func))
+    assert callable(normalize_response(Message(text="text")))
 
 
 def test_normalize_processing():
@@ -101,15 +101,15 @@ def test_normalize_processing():
         raise Exception("False processing")
 
     n_f = normalize_processing({1: true_processing_func})
-    assert isinstance(n_f, Callable)
+    assert callable(n_f)
     assert isinstance(n_f(ctx, actor), Context)
     n_f = normalize_processing({1: false_processing_func})
     assert isinstance(n_f(ctx, actor), Context)
 
     # TODO: Add full check for functions
-    assert isinstance(normalize_processing({}), Callable)
-    assert isinstance(normalize_processing({1: std_func}), Callable)
-    assert isinstance(normalize_processing({1: std_func, 2: std_func}), Callable)
+    assert callable(normalize_processing({}))
+    assert callable(normalize_processing({1: std_func}))
+    assert callable(normalize_processing({1: std_func, 2: std_func}))
 
 
 def test_normalize_keywords():

--- a/tests/script/core/test_script.py
+++ b/tests/script/core/test_script.py
@@ -1,6 +1,5 @@
 # %%
 import itertools
-from typing import Callable
 
 from dff.script import (
     GLOBAL,
@@ -92,7 +91,7 @@ def node_creation(pre_response_proc):
 
 def node_test(node: Node):
     assert list(node.transitions)[0] == ("", "node", float("-inf"))
-    assert isinstance(list(node.transitions.values())[0], Callable)
+    assert callable(list(node.transitions.values())[0])
     assert isinstance(node.pre_response_processing, dict)
     assert isinstance(node.pre_transitions_processing, dict)
     assert node.misc == {"key": "val"}


### PR DESCRIPTION
# Description

Replaces all instances of `isinstance(..., Callable)` with the built-in [`callable(...)`](https://docs.python.org/3/library/functions.html#callable).

Using `isinstance(..., Callable)` produces a mypy warning
```
Mypy: Argument 2 to "isinstance" has incompatible type "_SpecialForm"; expected "Union[type, UnionType, Tuple[Union[type, UnionType, Tuple[Any, ...]], ...]]"
```

Also, using built-in functions is preferable.

# Checklist

- [x] I have performed a self-review of the changes