### PR TITLE
Remove mutex from test_coverage

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -49,9 +49,6 @@ jobs:
           rm -rf /tmp/backup
           touch venv  # disable venv target
 
-      - name: set up mutex
-        uses: ben-z/gh-action-mutex@v1.0-alpha-6
-
       - name: run tests
         run: |
           make test


### PR DESCRIPTION
# Description

Remove mutex from test_coverage.
Mutex is currently not required since telegram is not tested via telegram api.

Removing mutex allows running test_coverage in dependabot PRs (although, it is very likely that the same can be achieved via permission changes).