### PR TITLE
Update std_labels.py

### DIFF
--- a/dff/script/labels/std_labels.py
+++ b/dff/script/labels/std_labels.py
@@ -32,7 +32,7 @@ def repeat(priority: Optional[float] = None, *args, **kwargs) -> Callable:
         if len(ctx.labels) >= 1:
             flow_label, label = list(ctx.labels.values())[-1]
         else:
-            flow_label, label = pipeline.actor.fallback_label[:2]
+            flow_label, label = pipeline.actor.start_label[:2]
         return (flow_label, label, current_priority)
 
     return repeat_transition_handler

--- a/dff/script/labels/std_labels.py
+++ b/dff/script/labels/std_labels.py
@@ -31,10 +31,8 @@ def repeat(priority: Optional[float] = None, *args, **kwargs) -> Callable:
         current_priority = pipeline.actor.label_priority if priority is None else priority
         if len(ctx.labels) >= 1:
             flow_label, label = list(ctx.labels.values())[-1]
-        elif len(ctx.labels) == 1:
-            flow_label, label = pipeline.actor.start_label[:2]
         else:
-            flow_label, label = pipeline.actor.fallback_label[:2]
+            flow_label, label = pipeline.actor.start_label[:2]
         return (flow_label, label, current_priority)
 
     return repeat_transition_handler

--- a/dff/script/labels/std_labels.py
+++ b/dff/script/labels/std_labels.py
@@ -53,6 +53,8 @@ def previous(priority: Optional[float] = None, *args, **kwargs) -> Callable:
         current_priority = pipeline.actor.label_priority if priority is None else priority
         if len(ctx.labels) >= 2:
             flow_label, label = list(ctx.labels.values())[-2]
+        elif len(ctx.labels) == 1:
+            flow_label, label = pipeline.actor.start_label[:2]
         else:
             flow_label, label = pipeline.actor.fallback_label[:2]
         return (flow_label, label, current_priority)

--- a/dff/script/labels/std_labels.py
+++ b/dff/script/labels/std_labels.py
@@ -45,6 +45,7 @@ def previous(priority: Optional[float] = None, *args, **kwargs) -> Callable:
     This handler returns a :py:const:`label <dff.script.NodeLabelType>`
     to the previous node with a given :py:const:`priority <float>`.
     If the priority is not given, `Pipeline.actor.label_priority` is used as default.
+    If the current node is the start node, fallback is returned.
 
     :param priority: Priority of transition. Uses `Pipeline.actor.label_priority` if priority not defined.
     """

--- a/dff/script/labels/std_labels.py
+++ b/dff/script/labels/std_labels.py
@@ -31,8 +31,10 @@ def repeat(priority: Optional[float] = None, *args, **kwargs) -> Callable:
         current_priority = pipeline.actor.label_priority if priority is None else priority
         if len(ctx.labels) >= 1:
             flow_label, label = list(ctx.labels.values())[-1]
-        else:
+        elif len(ctx.labels) == 1:
             flow_label, label = pipeline.actor.start_label[:2]
+        else:
+            flow_label, label = pipeline.actor.fallback_label[:2]
         return (flow_label, label, current_priority)
 
     return repeat_transition_handler

--- a/tests/script/labels/test_labels.py
+++ b/tests/script/labels/test_labels.py
@@ -5,15 +5,20 @@ from dff.script.labels import forward, repeat, previous, to_fallback, to_start, 
 
 def test_labels():
     ctx = Context()
-    ctx.add_label(["flow", "node1"])
-    ctx.add_label(["flow", "node2"])
-    ctx.add_label(["flow", "node3"])
-    ctx.add_label(["flow", "node2"])
+
     pipeline = Pipeline.from_script(
         script={"flow": {"node1": {}, "node2": {}, "node3": {}}, "service": {"start": {}, "fallback": {}}},
         start_label=("service", "start"),
         fallback_label=("service", "fallback"),
     )
+
+    assert repeat(99)(ctx, pipeline) == ("service", "start", 99)
+    assert previous(99)(ctx, pipeline) == ("service", "fallback", 99)
+
+    ctx.add_label(["flow", "node1"])
+    ctx.add_label(["flow", "node2"])
+    ctx.add_label(["flow", "node3"])
+    ctx.add_label(["flow", "node2"])
 
     assert repeat(99)(ctx, pipeline) == ("flow", "node2", 99)
     assert previous(99)(ctx, pipeline) == ("flow", "node3", 99)


### PR DESCRIPTION
# Description

From now on, `lbl.forward()` transition now works from start (first) label.

# Checklist

- [x] I have covered the code with tests
- [x] I have added comments to my code to help others understand it
- [x] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes