### PR TITLE
Remove args, kwargs from condition and label handler factories

### DIFF
--- a/dff/script/conditions/std_conditions.py
+++ b/dff/script/conditions/std_conditions.py
@@ -98,9 +98,7 @@ _all is an alias for all.
 
 
 @validate_arguments
-def aggregate(
-    cond_seq: list, aggregate_func: Callable = _any
-) -> Callable[[Context, Pipeline, Any, Any], bool]:
+def aggregate(cond_seq: list, aggregate_func: Callable = _any) -> Callable[[Context, Pipeline, Any, Any], bool]:
     """
     Aggregate multiple functions into one by using aggregating function.
 

--- a/dff/script/conditions/std_conditions.py
+++ b/dff/script/conditions/std_conditions.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 @validate_arguments
-def exact_match(match: Message, skip_none: bool = True, *args, **kwargs) -> Callable[..., bool]:
+def exact_match(match: Message, skip_none: bool = True) -> Callable[..., bool]:
     """
     Return function handler. This handler returns `True` only if the last user phrase
     is the same Message as the :py:const:`match`.
@@ -51,7 +51,7 @@ def exact_match(match: Message, skip_none: bool = True, *args, **kwargs) -> Call
 
 @validate_arguments
 def regexp(
-    pattern: Union[str, Pattern], flags: Union[int, re.RegexFlag] = 0, *args, **kwargs
+    pattern: Union[str, Pattern], flags: Union[int, re.RegexFlag] = 0
 ) -> Callable[[Context, Pipeline, Any, Any], bool]:
     """
     Return function handler. This handler returns `True` only if the last user phrase contains
@@ -99,7 +99,7 @@ _all is an alias for all.
 
 @validate_arguments
 def aggregate(
-    cond_seq: list, aggregate_func: Callable = _any, *args, **kwargs
+    cond_seq: list, aggregate_func: Callable = _any
 ) -> Callable[[Context, Pipeline, Any, Any], bool]:
     """
     Aggregate multiple functions into one by using aggregating function.
@@ -120,7 +120,7 @@ def aggregate(
 
 
 @validate_arguments
-def any(cond_seq: list, *args, **kwargs) -> Callable[[Context, Pipeline, Any, Any], bool]:
+def any(cond_seq: list) -> Callable[[Context, Pipeline, Any, Any], bool]:
     """
     Return function handler. This handler returns `True`
     if any function from the list is `True`.
@@ -136,7 +136,7 @@ def any(cond_seq: list, *args, **kwargs) -> Callable[[Context, Pipeline, Any, An
 
 
 @validate_arguments
-def all(cond_seq: list, *args, **kwargs) -> Callable[[Context, Pipeline, Any, Any], bool]:
+def all(cond_seq: list) -> Callable[[Context, Pipeline, Any, Any], bool]:
     """
     Return function handler. This handler returns `True` only
     if all functions from the list are `True`.
@@ -152,7 +152,7 @@ def all(cond_seq: list, *args, **kwargs) -> Callable[[Context, Pipeline, Any, An
 
 
 @validate_arguments
-def negation(condition: Callable, *args, **kwargs) -> Callable[[Context, Pipeline, Any, Any], bool]:
+def negation(condition: Callable) -> Callable[[Context, Pipeline, Any, Any], bool]:
     """
     Return function handler. This handler returns negation of the :py:func:`~condition`: `False`
     if :py:func:`~condition` holds `True` and returns `True` otherwise.
@@ -171,8 +171,6 @@ def has_last_labels(
     flow_labels: Optional[List[str]] = None,
     labels: Optional[List[NodeLabel2Type]] = None,
     last_n_indices: int = 1,
-    *args,
-    **kwargs,
 ) -> Callable[[Context, Pipeline, Any, Any], bool]:
     """
     Return condition handler. This handler returns `True` if any label from
@@ -199,7 +197,7 @@ def has_last_labels(
 
 
 @validate_arguments
-def true(*args, **kwargs) -> Callable[[Context, Pipeline, Any, Any], bool]:
+def true() -> Callable[[Context, Pipeline, Any, Any], bool]:
     """
     Return function handler. This handler always returns `True`.
     """
@@ -211,7 +209,7 @@ def true(*args, **kwargs) -> Callable[[Context, Pipeline, Any, Any], bool]:
 
 
 @validate_arguments
-def false(*args, **kwargs) -> Callable[[Context, Pipeline, Any, Any], bool]:
+def false() -> Callable[[Context, Pipeline, Any, Any], bool]:
     """
     Return function handler. This handler always returns `False`.
     """

--- a/dff/script/labels/std_labels.py
+++ b/dff/script/labels/std_labels.py
@@ -16,7 +16,7 @@ from dff.script import Context, NodeLabel3Type
 Pipeline = ForwardRef("Pipeline")
 
 
-def repeat(priority: Optional[float] = None, *args, **kwargs) -> Callable:
+def repeat(priority: Optional[float] = None) -> Callable:
     """
     Returns transition handler that takes :py:class:`.Context`,
     :py:class:`~dff.pipeline.Pipeline` and :py:const:`priority <float>`.
@@ -38,7 +38,7 @@ def repeat(priority: Optional[float] = None, *args, **kwargs) -> Callable:
     return repeat_transition_handler
 
 
-def previous(priority: Optional[float] = None, *args, **kwargs) -> Callable:
+def previous(priority: Optional[float] = None) -> Callable:
     """
     Returns transition handler that takes :py:class:`~dff.script.Context`,
     :py:class:`~dff.pipeline.Pipeline` and :py:const:`priority <float>`.
@@ -60,7 +60,7 @@ def previous(priority: Optional[float] = None, *args, **kwargs) -> Callable:
     return previous_transition_handler
 
 
-def to_start(priority: Optional[float] = None, *args, **kwargs) -> Callable:
+def to_start(priority: Optional[float] = None) -> Callable:
     """
     Returns transition handler that takes :py:class:`~dff.script.Context`,
     :py:class:`~dff.pipeline.Pipeline` and :py:const:`priority <float>`.
@@ -78,7 +78,7 @@ def to_start(priority: Optional[float] = None, *args, **kwargs) -> Callable:
     return to_start_transition_handler
 
 
-def to_fallback(priority: Optional[float] = None, *args, **kwargs) -> Callable:
+def to_fallback(priority: Optional[float] = None) -> Callable:
     """
     Returns transition handler that takes :py:class:`~dff.script.Context`,
     :py:class:`~dff.pipeline.Pipeline` and :py:const:`priority <float>`.
@@ -118,7 +118,7 @@ def _get_label_by_index_shifting(
     :return: The tuple that consists of `(flow_label, label, priority)`.
         If fallback is executed `(flow_fallback_label, fallback_label, priority)` are returned.
     """
-    flow_label, node_label, current_priority = repeat(priority, *args, **kwargs)(ctx, pipeline, *args, **kwargs)
+    flow_label, node_label, current_priority = repeat(priority)(ctx, pipeline, *args, **kwargs)
     labels = list(pipeline.script.get(flow_label, {}))
 
     if node_label not in labels:
@@ -133,7 +133,7 @@ def _get_label_by_index_shifting(
     return (flow_label, labels[label_index], current_priority)
 
 
-def forward(priority: Optional[float] = None, cyclicality_flag: bool = True, *args, **kwargs) -> Callable:
+def forward(priority: Optional[float] = None, cyclicality_flag: bool = True) -> Callable:
     """
     Returns transition handler that takes :py:class:`~dff.script.Context`,
     :py:class:`~dff.pipeline.Pipeline` and :py:const:`priority <float>`.
@@ -148,13 +148,13 @@ def forward(priority: Optional[float] = None, cyclicality_flag: bool = True, *ar
 
     def forward_transition_handler(ctx: Context, pipeline: Pipeline, *args, **kwargs) -> NodeLabel3Type:
         return _get_label_by_index_shifting(
-            ctx, pipeline, priority, increment_flag=True, cyclicality_flag=cyclicality_flag
+            ctx, pipeline, priority, increment_flag=True, cyclicality_flag=cyclicality_flag, *args, **kwargs
         )
 
     return forward_transition_handler
 
 
-def backward(priority: Optional[float] = None, cyclicality_flag: bool = True, *args, **kwargs) -> Callable:
+def backward(priority: Optional[float] = None, cyclicality_flag: bool = True) -> Callable:
     """
     Returns transition handler that takes :py:class:`~dff.script.Context`,
     :py:class:`~dff.pipeline.Pipeline` and :py:const:`priority <float>`.
@@ -169,7 +169,7 @@ def backward(priority: Optional[float] = None, cyclicality_flag: bool = True, *a
 
     def back_transition_handler(ctx: Context, pipeline: Pipeline, *args, **kwargs) -> NodeLabel3Type:
         return _get_label_by_index_shifting(
-            ctx, pipeline, priority, increment_flag=False, cyclicality_flag=cyclicality_flag
+            ctx, pipeline, priority, increment_flag=False, cyclicality_flag=cyclicality_flag, *args, **kwargs
         )
 
     return back_transition_handler


### PR DESCRIPTION
# Description

Remove `*args, **kwargs` from condition and label handler factories.
This makes it so that accidentally passing the factory instead of a handler in a script will cause an error.

# Checklist

- [ ] I have covered the code with tests
- [ ] I have added comments to my code to help others understand it
- [ ] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes