### PR TITLE
Remove addition of label during context init

### DIFF
--- a/dff/pipeline/pipeline/actor.py
+++ b/dff/pipeline/pipeline/actor.py
@@ -155,10 +155,10 @@ class Actor:
         del ctx.framework_states["actor"]
         return ctx
 
-    def _context_init(self, ctx: Optional[Union[Context, dict, str]] = None, *args, **kwargs) -> Context:
+    @staticmethod
+    def _context_init(ctx: Optional[Union[Context, dict, str]] = None, *args, **kwargs) -> Context:
         ctx = Context.cast(ctx)
         if not ctx.requests:
-            ctx.add_label(self.start_label[:2])
             ctx.add_request(Message())
         ctx.framework_states["actor"] = {}
         return ctx


### PR DESCRIPTION
# Description

During context init `start_label` is added to `ctx.labels` if `ctx.requests` is empty. The same does not happen when using pipeline (after the first request is added, there are no labels during actor execution).

This can lead to `ctx.label` having more items than `ctx.requests` or `ctx.responses` at the end of each turn.

# Checklist

- [ ] I have covered the code with tests
- [ ] I have added comments to my code to help others understand it
- [ ] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes