### PR TITLE
Fail tests on skip

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -51,4 +51,4 @@ jobs:
 
       - name: run tests
         run: |
-          make test
+          make test TEST_ALLOW_SKIP=telegram

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -46,8 +46,10 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
               source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /')
+              pytest --tb=long -vv --cache-clear --no-cov --allow-skip=telegram tests/
+          else
+              pytest --tb=long -vv --cache-clear --no-cov --allow-skip=telegram,docker tests/
           fi
-          pytest --tb=long -vv --cache-clear --no-cov tests/
         shell: bash
   test_no_deps:
     runs-on: "ubuntu-latest"
@@ -72,5 +74,5 @@ jobs:
       - name: run pytest
         run: |
           source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /')
-          pytest --tb=long -vv --cache-clear --no-cov tests/
+          pytest --tb=long -vv --cache-clear --no-cov --allow-skip=telegram tests/
         shell: bash

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -74,5 +74,5 @@ jobs:
       - name: run pytest
         run: |
           source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /')
-          pytest --tb=long -vv --cache-clear --no-cov --allow-skip=telegram tests/
+          pytest --tb=long -vv --cache-clear --no-cov --allow-skip=all tests/
         shell: bash

--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@ VENV_PATH = venv
 VERSIONING_FILES = setup.py makefile docs/source/conf.py dff/__init__.py
 CURRENT_VERSION = 0.4.2
 TEST_COVERAGE_THRESHOLD=95
+TEST_ALLOW_SKIP=telegram,docker
 
 PATH := $(VENV_PATH)/bin:$(PATH)
 
@@ -55,7 +56,7 @@ wait_db: docker_up
 .PHONY: wait_db
 
 test: venv
-	source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /') && pytest --cov-fail-under=$(TEST_COVERAGE_THRESHOLD) --cov-report html --cov-report term --cov=dff tests/
+	source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /') && pytest --cov-fail-under=$(TEST_COVERAGE_THRESHOLD) --cov-report html --cov-report term --cov=dff --allow-skip=$(TEST_ALLOW_SKIP) tests/
 .PHONY: test
 
 test_all: venv wait_db test lint

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ VENV_PATH = venv
 VERSIONING_FILES = setup.py makefile docs/source/conf.py dff/__init__.py
 CURRENT_VERSION = 0.4.2
 TEST_COVERAGE_THRESHOLD=95
-TEST_ALLOW_SKIP=telegram,docker
+TEST_ALLOW_SKIP=all  # for more info, see tests/conftest.py
 
 PATH := $(VENV_PATH)/bin:$(PATH)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 markers =
     docker: marks tests as requiring docker containers to work
     telegram: marks tests as requiring telegram client API token to work
+    all: reserved by allow-skip
+    none: reserved by allow-skip

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    docker: marks tests as requiring docker containers to work
+    telegram: marks tests as requiring telegram client API token to work

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+import pytest
+
+
+def pytest_report_header(config, start_path, startdir):
+    print(f"allow_skip: {config.getoption('--allow-skip') }")
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """
+    Fails tests that skip, if skipping them is not allowed via config.
+
+    Inspired by https://github.com/jankatins/pytest-error-for-skips.
+    """
+    outcome = yield
+    rep = outcome.get_result()
+
+    allow_skip = item.config.getoption("--allow-skip")
+
+    if allow_skip == "all":
+        return
+
+    test_marks = [mark.name for mark in item.own_markers]
+
+    # check that any of the permitted marks is present
+    if allow_skip != "None":
+        if any([mark in test_marks for mark in allow_skip.split(",")]):
+            return
+
+    if rep.skipped and call.excinfo.errisinstance(pytest.skip.Exception):
+        rep.outcome = "failed"
+        r = call.excinfo._getreprcrash()
+        rep.longrepr = "Forbidden skipped test - {message}".format(message=r.message)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--allow-skip",
+        action="store",
+        default="all",
+        help="A comma-separated list of marks. Any test without a mark from the list will fail on skip."
+        " If not passed, every test is permitted to skip."
+        " Pass `None` to disallow any test from skipping.",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def pytest_runtest_makereport(item, call):
     test_marks = [mark.name for mark in item.own_markers]
 
     # check that any of the permitted marks is present
-    if allow_skip != "None":
+    if allow_skip != "none":
         if any([mark in test_marks for mark in allow_skip.split(",")]):
             return
 
@@ -40,5 +40,5 @@ def pytest_addoption(parser):
         default="all",
         help="A comma-separated list of marks. Any test without a mark from the list will fail on skip."
         " If not passed, every test is permitted to skip."
-        " Pass `None` to disallow any test from skipping.",
+        " Pass `none` to disallow any test from skipping.",
     )

--- a/tests/context_storages/test_dbs.py
+++ b/tests/context_storages/test_dbs.py
@@ -123,6 +123,7 @@ def test_pickle(testing_file, testing_context, context_id):
 
 @pytest.mark.skipif(not MONGO_ACTIVE, reason="Mongodb server is not running")
 @pytest.mark.skipif(not mongo_available, reason="Mongodb dependencies missing")
+@pytest.mark.docker
 def test_mongo(testing_context, context_id):
     if system() == "Windows":
         pytest.skip()
@@ -140,6 +141,7 @@ def test_mongo(testing_context, context_id):
 
 @pytest.mark.skipif(not REDIS_ACTIVE, reason="Redis server is not running")
 @pytest.mark.skipif(not redis_available, reason="Redis dependencies missing")
+@pytest.mark.docker
 def test_redis(testing_context, context_id):
     db = context_storage_factory("redis://{}:{}@localhost:6379/{}".format("", os.getenv("REDIS_PASSWORD"), "0"))
     generic_test(db, testing_context, context_id)
@@ -148,6 +150,7 @@ def test_redis(testing_context, context_id):
 
 @pytest.mark.skipif(not POSTGRES_ACTIVE, reason="Postgres server is not running")
 @pytest.mark.skipif(not postgres_available, reason="Postgres dependencies missing")
+@pytest.mark.docker
 def test_postgres(testing_context, context_id):
     db = context_storage_factory(
         "postgresql+asyncpg://{}:{}@localhost:5432/{}".format(
@@ -170,6 +173,7 @@ def test_sqlite(testing_file, testing_context, context_id):
 
 @pytest.mark.skipif(not MYSQL_ACTIVE, reason="Mysql server is not running")
 @pytest.mark.skipif(not mysql_available, reason="Mysql dependencies missing")
+@pytest.mark.docker
 def test_mysql(testing_context, context_id):
     db = context_storage_factory(
         "mysql+asyncmy://{}:{}@localhost:3307/{}".format(
@@ -184,6 +188,7 @@ def test_mysql(testing_context, context_id):
 
 @pytest.mark.skipif(not YDB_ACTIVE, reason="YQL server not running")
 @pytest.mark.skipif(not ydb_available, reason="YDB dependencies missing")
+@pytest.mark.docker
 def test_ydb(testing_context, context_id):
     db = context_storage_factory(
         "{}{}".format(

--- a/tests/messengers/telegram/test_tutorials.py
+++ b/tests/messengers/telegram/test_tutorials.py
@@ -46,6 +46,7 @@ def test_client_tutorials_without_telegram(tutorial_module_name):
         "7_polling_setup",
     ],
 )
+@pytest.mark.telegram
 async def test_client_tutorials(tutorial_module_name, api_credentials, bot_user, session_file):
     tutorial_module = importlib.import_module(f"tutorials.{dot_path_to_addon}.{tutorial_module_name}")
     pipeline = tutorial_module.pipeline

--- a/tests/messengers/telegram/test_types.py
+++ b/tests/messengers/telegram/test_types.py
@@ -35,6 +35,7 @@ document = Document(source="https://github.com/mathiasbynens/small/raw/master/pd
 
 
 @pytest.mark.asyncio
+@pytest.mark.telegram
 async def test_text(pipeline_instance, api_credentials, bot_user, session_file):
     telegram_response = TelegramMessage(text="test")
     test_helper = TelegramTesting(
@@ -74,6 +75,7 @@ async def test_text(pipeline_instance, api_credentials, bot_user, session_file):
         ),
     ],
 )
+@pytest.mark.telegram
 async def test_buttons(ui, button_type, markup_type, pipeline_instance, api_credentials, bot_user, session_file):
     telegram_response = TelegramMessage(text="test", ui=ui)
     test_helper = TelegramTesting(
@@ -83,6 +85,7 @@ async def test_buttons(ui, button_type, markup_type, pipeline_instance, api_cred
 
 
 @pytest.mark.asyncio
+@pytest.mark.telegram
 async def test_keyboard_remove(pipeline_instance, api_credentials, bot_user, session_file):
     telegram_response = TelegramMessage(text="test", ui=RemoveKeyboard())
     test_helper = TelegramTesting(
@@ -116,6 +119,7 @@ async def test_keyboard_remove(pipeline_instance, api_credentials, bot_user, ses
         (Message(text="test", attachments=Attachments(files=[document])),),
     ],
 )
+@pytest.mark.telegram
 async def test_telegram_attachment(generic_response, pipeline_instance, api_credentials, bot_user, session_file):
     telegram_response = TelegramMessage.parse_obj(generic_response)
     test_helper = TelegramTesting(
@@ -149,6 +153,7 @@ async def test_telegram_attachment(generic_response, pipeline_instance, api_cred
         (Message(text="test", attachments=Attachments(files=2 * [document])),),
     ],
 )
+@pytest.mark.telegram
 async def test_attachments(attachments, pipeline_instance, api_credentials, bot_user, session_file):
     telegram_response = TelegramMessage.parse_obj(attachments)
     test_helper = TelegramTesting(
@@ -158,6 +163,7 @@ async def test_attachments(attachments, pipeline_instance, api_credentials, bot_
 
 
 @pytest.mark.asyncio
+@pytest.mark.telegram
 async def test_location(pipeline_instance, api_credentials, bot_user, session_file):
     telegram_response = TelegramMessage(text="location", location=Location(longitude=39.0, latitude=43.0))
     test_helper = TelegramTesting(
@@ -167,6 +173,7 @@ async def test_location(pipeline_instance, api_credentials, bot_user, session_fi
 
 
 @pytest.mark.asyncio
+@pytest.mark.telegram
 async def test_parsed_text(pipeline_instance, api_credentials, bot_user, session_file):
     telegram_response = TelegramMessage(text="[inline URL](http://www.example.com/)", parse_mode=ParseMode.MARKDOWN)
     test_helper = TelegramTesting(


### PR DESCRIPTION
# Description

Add a command line option for pytest that allows to specify tests which are allowed to skip.

If the option `--allow-skip` is not specified or `--allow-skip=all` is given, pytest works as usual:
```
tests/context_storages/test_dbs.py ......sss.ss
tests/messengers/telegram/test_tutorials.py ...ssssss
tests/messengers/telegram/test_types.py ssssssssssssss.....
```
(here docker is not up, telegram token is not given)

If pytest is given `--allow-skip=telegram`:
```
tests/context_storages/test_dbs.py ......EEE.EE
tests/messengers/telegram/test_tutorials.py ...ssssss
tests/messengers/telegram/test_types.py ssssssssssssss.....
```

If pytest is given `--allow-skip=telegram,docker`:
```
tests/context_storages/test_dbs.py ......sss.ss
tests/messengers/telegram/test_tutorials.py ...ssssss
tests/messengers/telegram/test_types.py ssssssssssssss.....
```

If pytest is given `--allow-skip=none`:
```
tests/context_storages/test_dbs.py ......EEE.EE
tests/messengers/telegram/test_tutorials.py ...EEEEEE
tests/messengers/telegram/test_types.py EEEEEEEEEEEEEE.....
```

Special markers `docker` and `telegram` are added to help sort the tests.

# Checklist

- [ ] I have covered the code with tests
- [x] I have added comments to my code to help others understand it
- [x] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes