### PR TITLE
add patch to supress warnings

### DIFF
--- a/docs/source/utils/patching.py
+++ b/docs/source/utils/patching.py
@@ -95,8 +95,8 @@ if __name__ == "__main__":
     wrap_source_function(depart_gallery_html, depart_gallery_html_wrapper)
     patch_source_file(getsourcefile(sphinx_autodoc_typehints), """
 class LoggerDummy():
-    def warning(*_, **__):
-        ...
+    def warning(self, message, *args):
+        print(f"Warning suppressed: {message % args}")
 
 _LOGGER = LoggerDummy()
 """)

--- a/docs/source/utils/patching.py
+++ b/docs/source/utils/patching.py
@@ -93,10 +93,13 @@ def depart_gallery_html_wrapper(func):
 if __name__ == "__main__":
     wrap_source_function(extract_summary, extract_summary_wrapper)
     wrap_source_function(depart_gallery_html, depart_gallery_html_wrapper)
-    patch_source_file(getsourcefile(sphinx_autodoc_typehints), """
+    patch_source_file(
+        getsourcefile(sphinx_autodoc_typehints),
+        """
 class LoggerDummy():
     def warning(self, message, *args):
         print(f"Warning suppressed: {message % args}")
 
 _LOGGER = LoggerDummy()
-""")
+""",
+    )

--- a/docs/source/utils/patching.py
+++ b/docs/source/utils/patching.py
@@ -5,6 +5,7 @@ from inspect import signature, getsourcefile, getsourcelines
 
 from sphinx.ext.autosummary import extract_summary
 from nbsphinx import depart_gallery_html
+import sphinx_autodoc_typehints
 
 logger = getLogger(__name__)
 logger.addHandler(StreamHandler())
@@ -92,3 +93,10 @@ def depart_gallery_html_wrapper(func):
 if __name__ == "__main__":
     wrap_source_function(extract_summary, extract_summary_wrapper)
     wrap_source_function(depart_gallery_html, depart_gallery_html_wrapper)
+    patch_source_file(getsourcefile(sphinx_autodoc_typehints), """
+class LoggerDummy():
+    def warning(*_, **__):
+        ...
+
+_LOGGER = LoggerDummy()
+""")

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ doc = merge_req_lists(
         "sphinx-favicon==1.0.1",
         "sphinx-copybutton==0.5.2",
         "sphinx-gallery==0.13.0",
-        "sphinx-autodoc-typehints==1.14.1",
+        "sphinx-autodoc-typehints==1.24.0",
         "nbsphinx==0.9.2",
         "jupytext==1.15.0",
         "jupyter==1.0.0",


### PR DESCRIPTION
# Description

Add patch to suppress warnings from `sphinx-autodoc-typehints`. The module uses `_LOGGER` to log and only accesses its `warning` method.

Passing doc workflow:
https://github.com/deeppavlov/dialog_flow_framework/actions/runs/5892243549

# Checklist

- [ ] I have covered the code with tests
- [ ] I have added comments to my code to help others understand it
- [ ] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes