### PR TITLE
Install local dff in tutorial tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -56,7 +56,7 @@ wait_db: docker_up
 .PHONY: wait_db
 
 test: venv
-	source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /') && pytest --cov-fail-under=$(TEST_COVERAGE_THRESHOLD) --cov-report html --cov-report term --cov=dff --allow-skip=$(TEST_ALLOW_SKIP) tests/
+	source <(cat .env_file | sed 's/=/=/' | sed 's/^/export /') && pytest -m "not no_coverage" --cov-fail-under=$(TEST_COVERAGE_THRESHOLD) --cov-report html --cov-report term --cov=dff --allow-skip=$(TEST_ALLOW_SKIP) tests/
 .PHONY: test
 
 test_all: venv wait_db test lint

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,6 @@ markers =
     docker: marks tests as requiring docker containers to work
     telegram: marks tests as requiring telegram client API token to work
     slow: marks tests as slow (taking more than a minute to complete)
+    no_coverage: tests that either cannot run inside the `coverage` workflow or do not affect coverage stats
     all: reserved by allow-skip
     none: reserved by allow-skip

--- a/tests/tutorials/test_tutorials.py
+++ b/tests/tutorials/test_tutorials.py
@@ -40,6 +40,7 @@ def check_tutorial_dependencies(venv: "VirtualEnv", tutorial_source_code: str):
 @pytest.mark.parametrize("dff_tutorial_py_file", DFF_TUTORIAL_PY_FILES)
 @pytest.mark.slow
 @pytest.mark.docker
+@pytest.mark.no_coverage
 def test_tutorials(dff_tutorial_py_file, virtualenv):
     with open(dff_tutorial_py_file, "r", encoding="utf-8") as fd:
         source_code = fd.read()

--- a/tests/tutorials/test_tutorials.py
+++ b/tests/tutorials/test_tutorials.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 import re
 from pathlib import Path
+import os
 
 import pytest
 
@@ -31,7 +32,7 @@ def check_tutorial_dependencies(venv: "VirtualEnv", tutorial_source_code: str):
         fd.write(tutorial_source_code)
 
     for deps in re.findall(InstallationCell.pattern, tutorial_source_code):
-        venv.run(f"python -m pip install {deps}", check_rc=True)
+        venv.run(f"python -m pip install {deps}".replace("dff", "."), check_rc=True, cd=os.getcwd())
 
     venv.run(f"python {tutorial_path}", check_rc=True)
 


### PR DESCRIPTION
# Description

Currently, every PR with additions (e.g. new dependencies or modules) fails due to tutorial tests which run `pip install dff` installing an older version from pypi.

This PR makes tutorial tests install local up-to-date dff.

Due to `coverage` workflow removing the `dff` directory from testing environment, this test cannot be run in `coverage` workflow (which is not a big problem since this test does not contribute to coverage at all).

Failing tests in `feat/db-benchmark`:
https://github.com/deeppavlov/dialog_flow_framework/pull/144/commits/5e604bd06fc63d9ad30002089c2092e03fb2c831

Successful tests with this patch:
https://github.com/deeppavlov/dialog_flow_framework/commit/8c791606cb9492913fc9d5e1b9eb08d911d5882e
![image](https://github.com/deeppavlov/dialog_flow_framework/assets/61429541/ed7a61bc-4869-4df2-bd50-87ac634fb062)


# Checklist

- [ ] I have covered the code with tests
- [ ] I have added comments to my code to help others understand it
- [x] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes