### PR TITLE
fix casting Message to TelegramMessage

### DIFF
--- a/dff/messengers/telegram/messenger.py
+++ b/dff/messengers/telegram/messenger.py
@@ -57,7 +57,9 @@ class TelegramMessenger(TeleBot):  # pragma: no cover
             ready_response = response
         elif isinstance(response, str):
             ready_response = TelegramMessage(text=response)
-        elif isinstance(response, dict) or isinstance(response, Message):
+        elif isinstance(response, Message):
+            ready_response = TelegramMessage.model_validate(response.model_dump())
+        elif isinstance(response, dict):
             ready_response = TelegramMessage.model_validate(response)
         else:
             raise TypeError(


### PR DESCRIPTION
# Description

Fix a bug where it was impossible to pass `Message` to Telegram Messenger Interface.

# Checklist

- [ ] I have covered the code with tests
- [ ] I have added comments to my code to help others understand it
- [ ] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes