### PR TITLE
Add member-order and exclude-members to autodoc config

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -146,7 +146,13 @@ favicons = [
 ]
 
 
-autodoc_default_options = {"members": True, "undoc-members": False, "private-members": True}
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": False,
+    "private-members": True,
+    "member-order": "bysource",
+    "exclude-members": "_abc_impl, model_fields",
+}
 
 
 def setup(_):


### PR DESCRIPTION
# Description

Add two config options for autodoc:

1. `member-order=bysource`: sort entries in API ref by the order of their appearance in the source code. This, among other things, fixes the order of enums:
    ![image](https://github.com/deeppavlov/dialog_flow_framework/assets/61429541/393d3d48-9173-4b02-a421-6d7298a5e949)
2. `exclude-members=_abc_impl, model_fields` excludes these fields from API ref. I left `model_config` since it may be useful information.

# Checklist

- [ ] I have covered the code with tests
- [ ] I have added comments to my code to help others understand it
- [ ] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes