### PR TITLE
Fix basic/full tutorial order

### DIFF
--- a/docs/source/utils/generate_tutorials.py
+++ b/docs/source/utils/generate_tutorials.py
@@ -68,7 +68,16 @@ def sort_tutorial_file_tree(files: Set[Path]) -> List[Path]:
     :param files: Files list to sort.
     """
     tutorials = {file for file in files if file.stem.split("_")[0].isdigit()}
-    return sorted(tutorials, key=lambda file: int(file.stem.split("_")[0])) + sorted(files - tutorials)
+
+    def sort_key(tutorial_file_name: Path) -> float:
+        tutorial_number = float(tutorial_file_name.stem.split("_")[0])
+
+        # full tutorials should go after tutorials with the same number
+        if tutorial_file_name.stem.endswith("_full"):
+            return tutorial_number + 0.5
+        return tutorial_number
+
+    return sorted(tutorials, key=sort_key) + sorted(files - tutorials)
 
 
 def iterate_tutorials_dir_generating_links(source: Path, dest: Path, base: str) -> List[Path]:


### PR DESCRIPTION
# Description

I previously reported the problem [here](https://github.com/deeppavlov/dialog_flow_framework/pull/136#discussion_r1302040968). As far as I remember, I later saw that everything on the site was in order and forgot about it.

However, at this moment tutorials are again out of order.
Although, this time, it's different tutorials that are out of order.

I ran locally `make doc` ~4 times and every time it was a different set of tutorials that were out of order.

This issue is caused by `sort_tutorial_file_tree` which sorts files that have a numerical prefix by that prefix. This function does not account for multiple tutorials with the same prefix in the same directory.

As a potential solution: the key function adds `0.5` to tutorials that end with `_full`.

# Checklist

- [ ] I have covered the code with tests
- [ ] I have added comments to my code to help others understand it
- [ ] I have updated the documentation to reflect the changes
- [ ] I have performed a self-review of the changes