### PR TITLE
Add docker volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     restart: unless-stopped
     ports:
       - 3307:3306
+    volumes:
+      - mysql-data:/var/lib/mysql
   psql:
     env_file: [.env_file]
     image: postgres:latest
@@ -16,6 +18,8 @@ services:
     restart: unless-stopped
     ports:
       - 5432:5432
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
   redis:
     env_file: [.env_file]
     image: redis:latest
@@ -25,6 +29,8 @@ services:
     command: --requirepass pass
     ports:
       - 6379:6379
+    volumes:
+      - redis-data:/data
   mongo:
     env_file: [.env_file]
     image: mongo:latest
@@ -33,6 +39,8 @@ services:
     restart: unless-stopped
     ports:
       - 27017:27017
+    volumes:
+      - mongo-data:/data/db
   ydb:
     env_file: [.env_file]
     image: cr.yandex/yc/yandex-docker-local-ydb:latest
@@ -44,6 +52,9 @@ services:
       # - 2135:2135
       - 2136:2136
     hostname: localhost
+    volumes:
+      - ydb-data:/ydb_data
+      - ydb-certs:/ydb_certs
   dashboard:
     env_file: [.env_file]
     build:
@@ -115,3 +126,9 @@ volumes:
     name: "ch-data"
   dashboard-data:
     name: "dashboard-data"
+  mysql-data:
+  postgres-data:
+  redis-data:
+  mongo-data:
+  ydb-data:
+  ydb-certs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,9 +123,7 @@ services:
       - "4318:4318"    # OTLP over HTTP receiver
 volumes:
   ch-data:
-    name: "ch-data"
   dashboard-data:
-    name: "dashboard-data"
   mysql-data:
   postgres-data:
   redis-data:


### PR DESCRIPTION
# Description

Add docker volumes for context storages to persist contexts after docker restart.

Adding tests for that would be difficult (due to the need to restart containers) but I tested that it works in codespaces and locally.

Although locally I have an issue with running `ydb` after adding volumes:
```
dff-ydb-1    | Caught exception: (No such file or directory) util/system/file.cpp:857: can't open "/ydb_certs/ca.pem" with mode RdOnly|Seq (0x00000028)
```
The issue is not present in codespaces (possibly due to clean environment).

UPD: removing ydb volumes and images and running again solves the issue.

Also, this PR removes names for `stats` volumes (I don't understand why we need them).

# Checklist

- [ ] I have covered the code with tests
- [ ] I have added comments to my code to help others understand it
- [ ] I have updated the documentation to reflect the changes
- [ ] I have performed a self-review of the changes