### PR TITLE
Fix stat tests

### DIFF
--- a/tests/stats/test_defaults.py
+++ b/tests/stats/test_defaults.py
@@ -37,13 +37,13 @@ async def test_get_current_label(context: Context, expected: set):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "context,expected",
+    "context",
     [
-        (Context(), set()),
-        (Context(labels={0: ("a", "b")}), {("flow", "a"), ("node", "b"), ("label", "a: b")}),
+        Context(),
+        Context(labels={0: ("a", "b")}),
     ],
 )
-async def test_otlp_integration(context, expected, tracer_exporter_and_provider, log_exporter_and_provider):
+async def test_otlp_integration(context, tracer_exporter_and_provider, log_exporter_and_provider):
     _, tracer_provider = tracer_exporter_and_provider
     log_exporter, logger_provider = log_exporter_and_provider
     tutorial_module = importlib.import_module("tutorials.stats.1_extractor_functions")

--- a/tests/stats/test_defaults.py
+++ b/tests/stats/test_defaults.py
@@ -46,9 +46,9 @@ async def test_get_current_label(context: Context, expected: set):
 async def test_otlp_integration(context, expected, tracer_exporter_and_provider, log_exporter_and_provider):
     _, tracer_provider = tracer_exporter_and_provider
     log_exporter, logger_provider = log_exporter_and_provider
-    example_module = importlib.import_module("tutorials.stats.1_extractor_functions")
-    example_module.dff_instrumentor.uninstrument()
-    example_module.dff_instrumentor.instrument(logger_provider=logger_provider, tracer_provider=tracer_provider)
+    tutorial_module = importlib.import_module("tutorials.stats.1_extractor_functions")
+    tutorial_module.dff_instrumentor.uninstrument()
+    tutorial_module.dff_instrumentor.instrument(logger_provider=logger_provider, tracer_provider=tracer_provider)
     runtime_info = ExtraHandlerRuntimeInfo(
         func=lambda x: x,
         stage="BEFORE",
@@ -56,7 +56,7 @@ async def test_otlp_integration(context, expected, tracer_exporter_and_provider,
             path=".", name=".", timeout=None, asynchronous=False, execution_state={".": "FINISHED"}
         ),
     )
-    _ = await default_extractors.get_current_label(context, example_module.pipeline, runtime_info)
+    _ = await default_extractors.get_current_label(context, tutorial_module.pipeline, runtime_info)
     tracer_provider.force_flush()
     logger_provider.force_flush()
     assert len(log_exporter.get_finished_logs()) > 0

--- a/tests/stats/test_defaults.py
+++ b/tests/stats/test_defaults.py
@@ -22,9 +22,7 @@ except ImportError:
 )
 async def test_get_current_label(context: Context, expected: set):
     pipeline = Pipeline.from_script(
-        {"greeting_flow": {"start_node": {}}},
-        ("greeting_flow", "start_node"),
-        validation_stage=False
+        {"greeting_flow": {"start_node": {}}}, ("greeting_flow", "start_node"), validation_stage=False
     )
     runtime_info = ExtraHandlerRuntimeInfo(
         func=lambda x: x,

--- a/tests/stats/test_defaults.py
+++ b/tests/stats/test_defaults.py
@@ -1,16 +1,15 @@
+import importlib
+
 import pytest
 
-try:
-    from wrapt import wrap_function_wrapper  # noqa: F401
-    from dff.stats import OtelInstrumentor
-except ImportError:
-    pytest.skip(allow_module_level=True, reason="One of the Opentelemetry packages is missing.")
-
-import importlib
 from dff.script import Context
 from dff.pipeline import Pipeline
 from dff.pipeline.types import ExtraHandlerRuntimeInfo, ServiceRuntimeInfo
-from dff.stats import default_extractors
+
+try:
+    from dff.stats import default_extractors
+except ImportError:
+    pytest.skip(allow_module_level=True, reason="One of the Opentelemetry packages is missing.")
 
 
 @pytest.mark.asyncio

--- a/tests/stats/test_defaults.py
+++ b/tests/stats/test_defaults.py
@@ -50,10 +50,8 @@ async def test_otlp_integration(context, expected, tracer_exporter_and_provider,
     _, tracer_provider = tracer_exporter_and_provider
     log_exporter, logger_provider = log_exporter_and_provider
     example_module = importlib.import_module("tutorials.stats.1_extractor_functions")
-    instrumentor = OtelInstrumentor()
-    if instrumentor.is_instrumented_by_opentelemetry:
-        instrumentor.uninstrument()
-    instrumentor.instrument(logger_provider=logger_provider, tracer_provider=tracer_provider)
+    example_module.dff_instrumentor.uninstrument()
+    example_module.dff_instrumentor.instrument(logger_provider=logger_provider, tracer_provider=tracer_provider)
     runtime_info = ExtraHandlerRuntimeInfo(
         func=lambda x: x,
         stage="BEFORE",

--- a/tests/stats/test_tutorials.py
+++ b/tests/stats/test_tutorials.py
@@ -33,15 +33,15 @@ CLICKHOUSE_DB = os.getenv("CLICKHOUSE_DB")
 )
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ["example_module_name", "expected_logs"],
+    ["tutorial_module_name", "expected_logs"],
     [
         ("1_extractor_functions", 10),
         ("2_pipeline_integration", 35),
     ],
 )
 @pytest.mark.docker
-async def test_examples_ch(example_module_name: str, expected_logs, otlp_log_exp_provider, otlp_trace_exp_provider):
-    module = importlib.import_module(f"tutorials.{dot_path_to_addon}.{example_module_name}")
+async def test_tutorials_ch(tutorial_module_name: str, expected_logs, otlp_log_exp_provider, otlp_trace_exp_provider):
+    module = importlib.import_module(f"tutorials.{dot_path_to_addon}.{tutorial_module_name}")
     _, tracer_provider = otlp_trace_exp_provider
     _, logger_provider = otlp_log_exp_provider
     http_client = AsyncClient()
@@ -59,21 +59,21 @@ async def test_examples_ch(example_module_name: str, expected_logs, otlp_log_exp
         assert count == expected_logs
 
     except Exception as exc:
-        raise Exception(f"model_name=tutorials.{dot_path_to_addon}.{example_module_name}") from exc
+        raise Exception(f"model_name=tutorials.{dot_path_to_addon}.{tutorial_module_name}") from exc
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ["example_module_name", "expected_logs"],
+    ["tutorial_module_name", "expected_logs"],
     [
         ("1_extractor_functions", 10),
         ("2_pipeline_integration", 35),
     ],
 )
-async def test_examples_memory(
-    example_module_name: str, expected_logs, tracer_exporter_and_provider, log_exporter_and_provider
+async def test_tutorials_memory(
+    tutorial_module_name: str, expected_logs, tracer_exporter_and_provider, log_exporter_and_provider
 ):
-    module = importlib.import_module(f"tutorials.{dot_path_to_addon}.{example_module_name}")
+    module = importlib.import_module(f"tutorials.{dot_path_to_addon}.{tutorial_module_name}")
     _, tracer_provider = tracer_exporter_and_provider
     log_exporter, logger_provider = log_exporter_and_provider
     try:
@@ -87,4 +87,4 @@ async def test_examples_memory(
         assert len(log_exporter.get_finished_logs()) == expected_logs
 
     except Exception as exc:
-        raise Exception(f"model_name=tutorials.{dot_path_to_addon}.{example_module_name}") from exc
+        raise Exception(f"model_name=tutorials.{dot_path_to_addon}.{tutorial_module_name}") from exc


### PR DESCRIPTION
# Description

This PR fixes issues I found with stats tests while investigating workflow failures:

------------

This PR fixes an issue with randomly failing workflows:

`test_get_current_label` was using a pipeline from `tutorials.stats.1_extractor_functions` which had `dff_instrumentor = OtelInstrumentor.from_url("grpc://localhost:4317")` and unlike other tests it was not `reinstrument`ed with an `InMemoryExporter`.

`test_get_current_label` is changed in the following way:

- A new pipeline is created for that test instead of importing it from a tutorial.
- Fix the way result is asserted (previously it did not fail when it should have).

------------

This PR updates the way instrumentor is reinstrumented in `test_otlp_integration` to the same way it is done in `test_tutorials` (by reinstrumenting an instrumentor from an imported tutorial instead of creating a new one).

------------

This PR replaces `example` with `tutorial` in stat tests.

------------

This PR removes unused `expected` parameter from `test_otlp_integration`.

------------

Also, while working on this issue I noticed that `otel_logs` have a null timestamp:
![image](https://github.com/deeppavlov/dialog_flow_framework/assets/61429541/06539796-fac5-4de8-ab47-3218a5669996)
_However, otel_traces does not have the same issue_

# Checklist

- [ ] I have covered the code with tests
- [ ] I have added comments to my code to help others understand it
- [ ] I have updated the documentation to reflect the changes
- [x] I have performed a self-review of the changes