### PR TITLE
Replace ForwardRef with TYPE_CHECKING

### DIFF
--- a/dff/__init__.py
+++ b/dff/__init__.py
@@ -9,3 +9,8 @@ __version__ = version(__name__)
 import nest_asyncio
 
 nest_asyncio.apply()
+
+from dff.pipeline import Pipeline
+from dff.script import Context, Script
+
+Script.model_rebuild()

--- a/dff/pipeline/__init__.py
+++ b/dff/pipeline/__init__.py
@@ -32,3 +32,5 @@ from .pipeline.pipeline import Pipeline, ACTOR
 from .service.extra import BeforeHandler, AfterHandler
 from .service.group import ServiceGroup
 from .service.service import Service, to_service
+
+ExtraHandlerRuntimeInfo.model_rebuild()

--- a/dff/pipeline/conditions.py
+++ b/dff/pipeline/conditions.py
@@ -5,7 +5,8 @@ The conditions module contains functions that can be used to determine whether t
 are attached should be executed or not.
 The standard set of them allows user to setup dependencies between pipeline components.
 """
-from typing import Optional, ForwardRef
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
 
 from dff.script import Context
 
@@ -16,7 +17,8 @@ from .types import (
     StartConditionCheckerAggregationFunction,
 )
 
-Pipeline = ForwardRef("Pipeline")
+if TYPE_CHECKING:
+    from dff.pipeline.pipeline.pipeline import Pipeline
 
 
 def always_start_condition(_: Context, __: Pipeline) -> bool:

--- a/dff/pipeline/pipeline/actor.py
+++ b/dff/pipeline/pipeline/actor.py
@@ -22,9 +22,10 @@ Both `request` and `response` are saved to :py:class:`.Context`.
 
 .. figure:: /_static/drawio/dfe/user_actor.png
 """
+from __future__ import annotations
 import logging
 import asyncio
-from typing import Union, Callable, Optional, Dict, List, ForwardRef
+from typing import Union, Callable, Optional, Dict, List, TYPE_CHECKING
 import copy
 
 from dff.utils.turn_caching import cache_clear
@@ -39,7 +40,8 @@ from dff.pipeline.service.utils import wrap_sync_function_in_async
 
 logger = logging.getLogger(__name__)
 
-Pipeline = ForwardRef("Pipeline")
+if TYPE_CHECKING:
+    from dff.pipeline.pipeline.pipeline import Pipeline
 
 
 def error_handler(error_msgs: list, msg: str, exception: Optional[Exception] = None, logging_flag: bool = True):

--- a/dff/pipeline/pipeline/component.py
+++ b/dff/pipeline/pipeline/component.py
@@ -8,11 +8,12 @@ step in a processing pipeline, and is responsible for performing a specific task
 The PipelineComponent class can be a group or a service. It is designed to be reusable and composable,
 allowing developers to create complex processing pipelines by combining multiple components.
 """
+from __future__ import annotations
 import logging
 import abc
 import asyncio
 import copy
-from typing import Optional, Awaitable, ForwardRef
+from typing import Optional, Awaitable, TYPE_CHECKING
 
 from dff.script import Context
 
@@ -31,7 +32,8 @@ from ..types import (
 
 logger = logging.getLogger(__name__)
 
-Pipeline = ForwardRef("Pipeline")
+if TYPE_CHECKING:
+    from dff.pipeline.pipeline.pipeline import Pipeline
 
 
 class PipelineComponent(abc.ABC):

--- a/dff/pipeline/service/extra.py
+++ b/dff/pipeline/service/extra.py
@@ -5,10 +5,11 @@ The Extra Handler module contains additional functionality that extends the capa
 beyond the core functionality. Extra handlers is an input converting addition to :py:class:`.PipelineComponent`.
 For example, it is used to grep statistics from components, timing, logging, etc.
 """
+from __future__ import annotations
 import asyncio
 import logging
 import inspect
-from typing import Optional, List, ForwardRef
+from typing import Optional, List, TYPE_CHECKING
 
 from dff.script import Context
 
@@ -23,7 +24,8 @@ from ..types import (
 
 logger = logging.getLogger(__name__)
 
-Pipeline = ForwardRef("Pipeline")
+if TYPE_CHECKING:
+    from dff.pipeline.pipeline.pipeline import Pipeline
 
 
 class _ComponentExtraHandler:

--- a/dff/pipeline/service/group.py
+++ b/dff/pipeline/service/group.py
@@ -7,9 +7,10 @@ This class provides a way to organize and manage multiple services as a single u
 allowing for easier management and organization of the services within the pipeline.
 The :py:class:`~.ServiceGroup` serves the important function of grouping services to work together in parallel.
 """
+from __future__ import annotations
 import asyncio
 import logging
-from typing import Optional, List, Union, Awaitable, ForwardRef
+from typing import Optional, List, Union, Awaitable, TYPE_CHECKING
 
 from dff.script import Context
 
@@ -29,7 +30,8 @@ from .service import Service
 
 logger = logging.getLogger(__name__)
 
-Pipeline = ForwardRef("Pipeline")
+if TYPE_CHECKING:
+    from dff.pipeline.pipeline.pipeline import Pipeline
 
 
 class ServiceGroup(PipelineComponent):

--- a/dff/pipeline/service/service.py
+++ b/dff/pipeline/service/service.py
@@ -9,9 +9,10 @@ Service is an atomic part of a pipeline.
 Service can be asynchronous only if its handler is a coroutine.
 Actor wrapping service is asynchronous.
 """
+from __future__ import annotations
 import logging
 import inspect
-from typing import Optional, ForwardRef
+from typing import Optional, TYPE_CHECKING
 
 from dff.script import Context
 
@@ -27,7 +28,8 @@ from ..pipeline.component import PipelineComponent
 
 logger = logging.getLogger(__name__)
 
-Pipeline = ForwardRef("Pipeline")
+if TYPE_CHECKING:
+    from dff.pipeline.pipeline.pipeline import Pipeline
 
 
 class Service(PipelineComponent):

--- a/dff/pipeline/types.py
+++ b/dff/pipeline/types.py
@@ -6,7 +6,6 @@ The classes and special types in this module can include data models,
 data structures, and other types that are defined for type hinting.
 """
 from __future__ import annotations
-from abc import ABC
 from enum import unique, Enum
 from typing import Callable, Union, Awaitable, Dict, List, Optional, Iterable, Any, Protocol, Hashable, TYPE_CHECKING
 

--- a/dff/script/core/context.py
+++ b/dff/script/core/context.py
@@ -16,18 +16,20 @@ Another important feature of the context is data serialization.
 The context can be easily serialized to a format that can be stored or transmitted, such as JSON.
 This allows developers to save the context data and resume the conversation later.
 """
+from __future__ import annotations
 import logging
 from uuid import UUID, uuid4
-from typing import Any, Optional, Union, Dict, List, Set
+from typing import Any, Optional, Union, Dict, List, Set, TYPE_CHECKING
 
 from pydantic import BaseModel, Field, field_validator
 
 from .types import NodeLabel2Type, ModuleName
 from .message import Message
 
-logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from dff.script.core.script import Node
 
-Node = BaseModel
+logger = logging.getLogger(__name__)
 
 
 def get_last_index(dictionary: dict) -> int:
@@ -120,7 +122,7 @@ class Context(BaseModel):
         return {key: dictionary[key] for key in sorted(dictionary)}
 
     @classmethod
-    def cast(cls, ctx: Optional[Union["Context", dict, str]] = None, *args, **kwargs) -> "Context":
+    def cast(cls, ctx: Optional[Union[Context, dict, str]] = None, *args, **kwargs) -> Context:
         """
         Transform different data types to the objects of the
         :py:class:`~.Context` class.
@@ -277,6 +279,3 @@ class Context(BaseModel):
             )
 
         return node
-
-
-Context.model_rebuild()

--- a/dff/script/core/normalization.py
+++ b/dff/script/core/normalization.py
@@ -5,20 +5,19 @@ Normalization module is used to normalize all python objects and functions to a 
 that is suitable for script and actor execution process.
 This module contains a basic set of functions for normalizing data in a dialog script.
 """
+from __future__ import annotations
 import logging
-
-from typing import Union, Callable, Optional, ForwardRef
+from typing import Union, Callable, Optional, TYPE_CHECKING
 
 from .keywords import Keywords
 from .context import Context
 from .types import NodeLabel3Type, NodeLabelType, ConditionType, LabelType
 from .message import Message
 
-from pydantic import validate_call
+if TYPE_CHECKING:
+    from dff.pipeline.pipeline.pipeline import Pipeline
 
 logger = logging.getLogger(__name__)
-
-Pipeline = ForwardRef("Pipeline")
 
 
 def normalize_label(
@@ -83,10 +82,9 @@ def normalize_condition(condition: ConditionType) -> Callable[[Context, Pipeline
         return callable_condition_handler
 
 
-@validate_call
 def normalize_response(
-    response: Optional[Union[Message, Callable[[Context, Pipeline], Message]]]
-) -> Callable[[Context, Pipeline], Message]:
+    response: Optional[Union[Message, Callable[[Context, "Pipeline"], Message]]]
+) -> Callable[[Context, "Pipeline"], Message]:
     """
     This function is used to normalize response. If the response is a Callable, it is returned, otherwise
     the response is wrapped in an asynchronous function and this function is returned.

--- a/dff/script/core/script.py
+++ b/dff/script/core/script.py
@@ -6,23 +6,22 @@ These models are used to define the conversation flow, and to determine the appr
 the user's input and the current state of the conversation.
 """
 # %%
-
+from __future__ import annotations
 import logging
-from typing import Callable, Optional, Any, Dict, Union
+from typing import Callable, Optional, Any, Dict, Union, TYPE_CHECKING
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, validate_call
 
 from .types import LabelType, NodeLabelType, ConditionType, NodeLabel3Type
 from .message import Message
 from .keywords import Keywords
-from .normalization import normalize_condition, normalize_label, validate_call
-from typing import ForwardRef
+from .normalization import normalize_condition, normalize_label
+
+if TYPE_CHECKING:
+    from dff.script.core.context import Context
+    from dff.pipeline.pipeline.pipeline import Pipeline
 
 logger = logging.getLogger(__name__)
-
-
-Pipeline = ForwardRef("Pipeline")
-Context = ForwardRef("Context")
 
 
 class Node(BaseModel, extra="forbid", validate_assignment=True):

--- a/dff/script/labels/std_labels.py
+++ b/dff/script/labels/std_labels.py
@@ -10,10 +10,12 @@ such as the current context or user data, to create more complex and dynamic con
 This module contains a standard set of scripting :py:const:`labels <dff.script.NodeLabelType>` that
 can be used by developers to define the conversation flow.
 """
-from typing import Optional, Callable, ForwardRef
+from __future__ import annotations
+from typing import Optional, Callable, TYPE_CHECKING
 from dff.script import Context, NodeLabel3Type
 
-Pipeline = ForwardRef("Pipeline")
+if TYPE_CHECKING:
+    from dff.pipeline.pipeline.pipeline import Pipeline
 
 
 def repeat(priority: Optional[float] = None) -> Callable:


### PR DESCRIPTION
# Description

When type import would cause cyclic import error, instead of defining types as `ForwardRef`s or pydantic's `BaseModel`s, use `TYPE_CHECKING`.

This helps tools that work with typing such as `mypy` (this PR reduces the number of errors found with `mypy` from 208 to 145).

# Checklist

- [x] I have performed a self-review of the changes

# To Consider

- Add tests (if functionality is changed)
- Update API reference / tutorials / guides
- Update CONTRIBUTING.md (if devel workflow is changed)
- Update `.ignore` files, scripts (such as `lint`), distribution manifest (if files are added/deleted)
- Search for references to changed entities in the codebase